### PR TITLE
PHB/XGTE expertise elements and fixes

### DIFF
--- a/core/players-handbook/classes/class-rogue.xml
+++ b/core/players-handbook/classes/class-rogue.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-  <info>
-    <name>Rogue</name>
-    <description>The Rogue class from the Player’s Handbook.</description>
-    <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-    <update version="0.2.1">
-      <file name="class-rogue.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/classes/class-rogue.xml" />
-    </update>
-  </info>
-
+	<info>
+		<name>Rogue</name>
+		<description>The Rogue class from the Player’s Handbook.</description>
+		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
+		<update version="0.2.2">
+			<file name="class-rogue.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/classes/class-rogue.xml" />
+		</update>
+	</info>
 
   <element name="Rogue" type="Class" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_ROGUE">
     <supports />
@@ -455,7 +454,6 @@
       <grant type="Grants" id="ID_INTERNAL_GRANT_MULTICLASS_SPELLCASTING_SLOTS_THIRD" requirements="ID_INTERNAL_GRANT_MULTICLASS" />
     </rules>
   </element>
-
   <element name="Spellcasting" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_ARCANE_TRICKSTER_SPELLCASTING">
     <description>
       <p>When you reach 3rd level, you gain the ability to cast spells. See chapter 10 for the general rules of spellcasting and chapter 11 for the wizard spell list.</p>
@@ -513,7 +511,6 @@
       
     </rules>
   </element>
-
   <element name="Mage Hand Legerdemain" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_ARCANE_TRICKSTER_MAGE_HAND_LEGERDEMAIN">
     <description>
       <p>Starting at 3rd level, when you cast mage hand, you can make the spectral hand invisible, and you can perform the following additional tasks with it:</p>
@@ -534,7 +531,6 @@
       <!-- implement: set details on the mage hand spell -->
     </rules>
   </element>
-
   <element name="Magical Ambush" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_ARCANE_TRICKSTER_MAGICAL_AMBUSH">
     <description>
       <p>Starting at 9th level, if you are hidden from a creature when you cast a spell on it, the creature has disadvantage on any saving throw it makes against the spell this turn.</p>
@@ -544,7 +540,6 @@
     </sheet>
     <rules />
   </element>
-
   <element name="Versatile Trickster" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_ARCANE_TRICKSTER_VERSATILE_TRICKSTER">
     <description>
       <p>At 13th level, you gain the ability to distract targets with your mage hand. As a bonus action on your turn, you can designate a creature within 5 feet of the spectral hand created by the spell. Doing so gives you advantage on attack rolls against that creature until the end of the turn.</p>
@@ -554,7 +549,6 @@
     </sheet>
     <rules />
   </element>
-
   <element name="Spell Thief" type="Archetype Feature" source="Player’s Handbook" id="ID_WOTC_PHB_ARCHETYPE_FEATURE_ARCANE_TRICKSTER_SPELL_THIEF">
     <description>
       <p>At 17th level, you gain the ability to magically steal the knowledge of how to cast a spell from another spellcaster.</p>
@@ -566,5 +560,216 @@
     </sheet>
     <rules />
   </element>
+
+	<!-- Expertise -->
+	<element name="Skill Expertise (Acrobatics)" type="Class Feature" id="ID_EXPERTISE_SKILL_ACROBATICS" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_ACROBATICS</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Acrobatics check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_ACROBATICS" />
+		</description>
+		<rules>
+			<stat name="Acrobatics Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Animal Handling)" type="Class Feature" id="ID_EXPERTISE_SKILL_ANIMALHANDLING" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_ANIMALHANDLING</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Animal Handling check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_ACROBATICS" />
+		</description>
+		<rules>
+			<stat name="Animal Handling Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Arcana)" type="Class Feature" id="ID_EXPERTISE_SKILL_ARCANA" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_ARCANA</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Arcana check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_ARCANA" />
+		</description>
+		<rules>
+			<stat name="Arcana Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Athletics)" type="Class Feature" id="ID_EXPERTISE_SKILL_ATHLETICS" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_ATHLETICS</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Athletics check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_ATHLETICS" />
+		</description>
+		<rules>
+			<stat name="Athletics Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Deception)" type="Class Feature" id="ID_EXPERTISE_SKILL_DECEPTION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_DECEPTION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Deception check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_DECEPTION" />
+		</description>
+		<rules>
+			<stat name="Deception Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (History)" type="Class Feature" id="ID_EXPERTISE_SKILL_HISTORY" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_HISTORY</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any History check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_HISTORY" />
+		</description>
+		<rules>
+			<stat name="History Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Insight)" type="Class Feature" id="ID_EXPERTISE_SKILL_INSIGHT" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_INSIGHT</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Insight check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_INSIGHT" />
+		</description>
+		<rules>
+			<stat name="Insight Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Intimidation)" type="Class Feature" id="ID_EXPERTISE_SKILL_INTIMIDATION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_INTIMIDATION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Intimidation check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_INTIMIDATION" />
+		</description>
+		<rules>
+			<stat name="Intimidation Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Investigation)" type="Class Feature" id="ID_EXPERTISE_SKILL_INVESTIGATION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_INVESTIGATION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Investigation check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_INVESTIGATION" />
+		</description>
+		<rules>
+			<stat name="Investigation Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Medicine)" type="Class Feature" id="ID_EXPERTISE_SKILL_MEDICINE" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_MEDICINE</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Medicine check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_MEDICINE" />
+		</description>
+		<rules>
+			<stat name="Medicine Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Nature)" type="Class Feature" id="ID_EXPERTISE_SKILL_NATURE" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_NATURE</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Nature check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_NATURE" />
+		</description>
+		<rules>
+			<stat name="Nature Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Perception)" type="Class Feature" id="ID_EXPERTISE_SKILL_PERCEPTION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_PERCEPTION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Perception check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_PERCEPTION" />
+		</description>
+		<rules>
+			<stat name="Perception Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Performance)" type="Class Feature" id="ID_EXPERTISE_SKILL_PERFORMANCE" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_PERFORMANCE</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Performance check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_PERFORMANCE" />
+		</description>
+		<rules>
+			<stat name="Performance Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Persuasion)" type="Class Feature" id="ID_EXPERTISE_SKILL_PERSUASION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_PERSUASION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Persuasion check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_PERSUASION" />
+		</description>
+		<rules>
+			<stat name="Persuasion Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Religion)" type="Class Feature" id="ID_EXPERTISE_SKILL_RELIGION" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_RELIGION</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Religion check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_RELIGION" />
+		</description>
+		<rules>
+			<stat name="Religion Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Sleight of Hand)" type="Class Feature" id="ID_EXPERTISE_SKILL_SLEIGHTOFHAND" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_SLEIGHTOFHAND</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Sleight of Hand check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_SLEIGHTOFHAND" />
+		</description>
+		<rules>
+			<stat name="Sleight of Hand Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Stealth)" type="Class Feature" id="ID_EXPERTISE_SKILL_STEALTH" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_STEALTH</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Stealth check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_STEALTH" />
+		</description>
+		<rules>
+			<stat name="Stealth Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Skill Expertise (Survival)" type="Class Feature" id="ID_EXPERTISE_SKILL_SURVIVAL" source="Player’s Handbook">
+		<supports>Expertise, Skill, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_SKILL_SURVIVAL</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Survival check you make.</p>
+			<div element="ID_PROFICIENCY_SKILL_SURVIVAL" />
+		</description>
+		<rules>
+			<stat name="Survival Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
+	<element name="Tool Expertise (Thieves’ Tools)" type="Class Feature" id="ID_EXPERTISE_TOOL_THIEVES_TOOLS" source="Player’s Handbook">
+		<supports>Expertise, Tool, ID_INTERNAL_SUPPORT_EXPERTISE</supports>
+		<requirements>ID_PROFICIENCY_TOOL_PROFICIENCY_THIEVES_TOOLS</requirements>
+		<description>
+			<p>Your proficiency bonus is doubled for any Thieves’ Tools check you make.</p>
+			<div element="ID_PROFICIENCY_TOOL_PROFICIENCY_THIEVES_TOOLS" />
+		</description>
+		<rules>
+			<stat name="Thieves’ Tools Proficiency" value="Proficiency" bonus="expertise" />
+		</rules>
+	</element>
 
 </elements>

--- a/supplements/xanathars-guide-to-everything/archetypes/rogue-scout.xml
+++ b/supplements/xanathars-guide-to-everything/archetypes/rogue-scout.xml
@@ -4,7 +4,7 @@
         <name>Scout</name>
         <description>The Scout from Xanathar’s Guide to Everything</description>
         <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="rogue-scout.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/supplements/xanathars-guide-to-everything/archetypes/rogue-scout.xml" />
         </update>
     </info>
@@ -46,9 +46,8 @@
         <rules>
             <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_NATURE" requirements="!ID_PROFICIENCY_SKILL_NATURE"/>
             <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_SURVIVAL" requirements="!ID_PROFICIENCY_SKILL_SURVIVAL" />
-            <!-- ability checks, not standard skill checks -->
-            <!-- <stat name="Nature Proficiency" value="Proficiency" bonus="expertise" /> -->
-            <!-- <stat name="Survival Proficiency" value="Proficiency" bonus="expertise" /> -->
+            <stat name="Nature Proficiency" value="Proficiency" bonus="expertise" />
+            <stat name="Survival Proficiency" value="Proficiency" bonus="expertise" />
         </rules>
     </element>
     <element name="Superior Moblility" type="Archetype Feature" source="Xanathar’s Guide to Everything" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_SCOUT_SUPERIOR_MOBILITY">


### PR DESCRIPTION
Adding expertise elements into the Rogue class file and adding the description of the skill in the description of the expertise element for reference.

Fixes for: 
- unable to select Investigation expertise
- for doubling proficiency on Scout (Roguish Archetype)