### PR TITLE
CoS background misprint fix

### DIFF
--- a/supplements/curse-of-strahd/backgrounds/background-hauntedone.xml
+++ b/supplements/curse-of-strahd/backgrounds/background-hauntedone.xml
@@ -2,10 +2,10 @@
 <elements>
     <info>
         <name>Haunted One</name>
-        <description>The Haunted One background from Curse of Stradh</description>
-        <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/curse-strahd">Curse of Stradh</author>
-        <update version="0.0.2">
-            <file name="background-hauntedone.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/supplements/curse-of-stradh/backgrounds/background-hauntedone.xml" />
+        <description>The Haunted One background from Curse of Strahd</description>
+        <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/curse-strahd">Curse of Strahd</author>
+        <update version="0.0.3">
+            <file name="background-hauntedone.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/supplements/curse-of-strahd/backgrounds/background-hauntedone.xml" />
         </update>
     </info>
     <element name="Haunted One" type="Background" source="Curse of Strahd" id="ID_COS_BACKGROUND_HAUNTED_ONE">

--- a/supplements/curse-of-strahd/backgrounds/background-hauntedone.xml
+++ b/supplements/curse-of-strahd/backgrounds/background-hauntedone.xml
@@ -12,7 +12,7 @@
         <description>
             <p>You are haunted by something so terrible that you dare not speak of it. You’ve tried to bury it and flee from it to no avail. This thing that haunts you can’t be slain with a sword or banished with a spell. It might come to you as a shadow on the wall, a bloodcurdling nightmare, a memory that refuses to die, or a demonic whisper in the dark. The burden has taken its toll, isolating you from others and making you question your sanity. You must find a way to overcome it before it destroys you.</p>
             <p>
-                <span class="emphasis">Skill Proficiencies:</span>Choose one from among Arcana, Investigation, Religion, and Survival<br/>
+                <span class="emphasis">Skill Proficiencies:</span>Choose two from among Arcana, Investigation, Religion, and Survival<br/>
                 <span class="emphasis">Languages:</span>Choose one exotic language (Abyssal, Celestial, Deep Speech, Draconic, Infernal, Primordial, Sylvan, or Undercommon)<br/>
                 <span class="emphasis">Equipment:</span>A monster hunter’s pack, a set of common clothes, and one trinket of special significance (see below), and a belt pouch containing 15 gp.
             </p>
@@ -95,7 +95,7 @@
             <p>You have learned to live with the terror that haunts you. You are a survivor, who can be very protective of those who bring light into your darkened life.</p>
         </description>
         <rules>
-            <select type="Proficiency" name="Skill Proficiency (Haunted One)" supports="ID_PROFICIENCY_SKILL_ARCANA|ID_PROFICIENCY_SKILL_INVESTIGATION|ID_PROFICIENCY_SKILL_RELIGION|ID_PROFICIENCY_SKILL_SURVIVAL" />
+            <select type="Proficiency" name="Skill Proficiency (Haunted One)" supports="ID_PROFICIENCY_SKILL_ARCANA|ID_PROFICIENCY_SKILL_INVESTIGATION|ID_PROFICIENCY_SKILL_RELIGION|ID_PROFICIENCY_SKILL_SURVIVAL" number="2" />
             <select type="Language" name="Language (Haunted One)" supports="ID_LANGUAGE_ABYSSAL|ID_LANGUAGE_CELESTIAL|ID_LANGUAGE_DEEP_SPEECH|ID_LANGUAGE_DRACONIC|ID_LANGUAGE_INFERNAL|ID_LANGUAGE_PRIMORDIAL|ID_LANGUAGE_SYLVAN|ID_LANGUAGE_UNDERCOMMON" number="1" />
             <grant type="Background Feature" id="ID_COS_BACKGROUND_HAUNTED_ONE_HEART_OF_DARKNESS" />
             <select name="Personality Trait" type="List" number="2">


### PR DESCRIPTION
CoS (pg 209) was misprinted, Haunted One background should have a choice of 2 proficiencies not 1.

Reference:
https://twitter.com/JeremyECrawford/status/705467140246106112
from https://www.sageadvice.eu/2016/03/04/haunted-one-background-explained-curse-of-strahd/

Updated background description and added a proficiency choice.