### PR TITLE
Added D&DWiki Katana

### DIFF
--- a/third-party/dnd-wiki.index
+++ b/third-party/dnd-wiki.index
@@ -4,7 +4,7 @@
 		<name>D&amp;D Wiki</name>
 		<description>The 5e homebrew content from the D&amp;D Wiki website.</description>
 		<author url="http://www.dandwiki.com/wiki/5e_Homebrew">D&amp;D Wiki</author>
-		<update version="0.0.8">
+		<update version="0.0.9">
 			<file name="dnd-wiki.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki.index" />
 		</update>
 	</info>
@@ -30,6 +30,8 @@
 		<!-- spells -->
 		<file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/spells.xml" />
 
+		<!-- items -->
+        <file name="items-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/items/items-weapons.xml" />
 
 	</files>
 </index>

--- a/third-party/dnd-wiki.index
+++ b/third-party/dnd-wiki.index
@@ -31,7 +31,7 @@
 		<file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/spells.xml" />
 
 		<!-- items -->
-        <file name="items-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/items/items-weapons.xml" />
+		<file name="items-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/items/items-weapons.xml" />
 
 	</files>
 </index>

--- a/third-party/dnd-wiki/items/items-weapons.xml
+++ b/third-party/dnd-wiki/items/items-weapons.xml
@@ -2,47 +2,49 @@
 <elements>
 	<info>
 		<name>Weapons from D&amp;D Wiki</name>
-        <description>5e homebrew</description>
+        <description>5E Homebrew weapons from D&amp;D Wiki</description>
         <author url="http://www.dandwiki.com/wiki/5e_Homebrew">D&amp;D Wiki</author>
         <update version="0.1">
             <file name="items-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/items/items-weapons.xml" />
         </update>
 	</info>
-	<element name="Katana" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_KATANA">
+	<element name="Katana" type="Weapon" source="D&amp;D Wiki" id="ID_WIKI_WEAPON_KATANA">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_VERSATILE, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
 		<description>
-			<p></p>
+			<p>In some cultures this strong, single-edged sword is a symbol of honor and prestige. The katana is intended for two-handed use, but it's light enough to be wielded one-handed. </p>
 		</description>
 		<setters>
+			<set name="url">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
 			<set name="category">Weapons</set>
 			<set name="cost" currency="gp">15</set>
 			<set name="weight" lb="3">3 lb.</set>
 			<set name="slot">onehand</set>
 			<set name="damage" type="slashing">1d8</set>
 			<set name="versatile">1d10</set>
-			<set name="proficiency">ID_BREW_WEAPON_PROFICIENCY_KATANA</set>
+			<set name="proficiency">ID_WIKI_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
 		</setters>
 	</element>
-	<element name="Katana, Finesse" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_LIGHT_KATANA">
+	<element name="Katana, Finesse" type="Weapon" source="D&amp;D Wiki" id="ID_WIKI_WEAPON_LIGHT_KATANA">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
 		<description>
-			<p></p>
+			<p>Historically, katana widely varied in size and weight. If you would prefer a katana that emphasizes fast, precise cuts, then you can choose this variation instead. </p>
 		</description>
 		<setters>
+			<set name="url">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
 			<set name="category">Weapons</set>
 			<set name="cost" currency="gp">15</set>
 			<set name="weight" lb="2">2 lb.</set>
 			<set name="slot">onehand</set>
 			<set name="damage" type="slashing">1d8</set>
-			<set name="proficiency">ID_BREW_WEAPON_PROFICIENCY_KATANA</set>
+			<set name="proficiency">ID_WIKI_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
 		</setters>
 	</element>
-	<element name="Weapon Proficiency (Katana)" type="Proficiency" source="D&amp;D Wiki" id="ID_BREW_WEAPON_PROFICIENCY_KATANA">
+	<element name="Weapon Proficiency (Katana)" type="Proficiency" source="D&amp;D Wiki" id="ID_WIKI_PROFICIENCY_WEAPON_PROFICIENCY_KATANA">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
 	</element>
 	<append id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_MELEE_WEAPONS">
 		<rules>
-			<grant type="Proficiency" id="ID_BREW_WEAPON_PROFICIENCY_KATANA" />
+			<grant type="Proficiency" id="ID_WIKI_PROFICIENCY_WEAPON_PROFICIENCY_KATANA" />
 		</rules>
 	</append>
 </elements>

--- a/third-party/dnd-wiki/items/items-weapons.xml
+++ b/third-party/dnd-wiki/items/items-weapons.xml
@@ -14,7 +14,7 @@
 			<p>In some cultures this strong, single-edged sword is a symbol of honor and prestige. The katana is intended for two-handed use, but it's light enough to be wielded one-handed. </p>
 		</description>
 		<setters>
-			<set name="url">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
+			<set name="sourceUrl">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
 			<set name="category">Weapons</set>
 			<set name="cost" currency="gp">15</set>
 			<set name="weight" lb="3">3 lb.</set>
@@ -30,7 +30,7 @@
 			<p>Historically, katana widely varied in size and weight. If you would prefer a katana that emphasizes fast, precise cuts, then you can choose this variation instead. </p>
 		</description>
 		<setters>
-			<set name="url">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
+			<set name="sourceUrl">https://www.dandwiki.com/wiki/Katana_(5e_Equipment)</set>
 			<set name="category">Weapons</set>
 			<set name="cost" currency="gp">15</set>
 			<set name="weight" lb="2">2 lb.</set>

--- a/third-party/dnd-wiki/items/items-weapons.xml
+++ b/third-party/dnd-wiki/items/items-weapons.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<name>Weapons from D&amp;D Wiki</name>
+        <description>5e homebrew</description>
+        <author url="http://www.dandwiki.com/wiki/5e_Homebrew">D&amp;D Wiki</author>
+        <update version="0.1">
+            <file name="items-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/items/items-weapons.xml" />
+        </update>
+	</info>
+	<element name="Katana" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_KATANA">
+		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_VERSATILE, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="category">Weapons</set>
+			<set name="cost" currency="gp">15</set>
+			<set name="weight" lb="3">3 lb.</set>
+			<set name="slot">onehand</set>
+			<set name="damage" type="slashing">1d8</set>
+			<set name="versatile">1d10</set>
+			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
+		</setters>
+	</element>
+	<element name="Finesse Katana" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_LIGHT_KATANA">
+		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="category">Weapons</set>
+			<set name="cost" currency="gp">15</set>
+			<set name="weight" lb="2">2 lb.</set>
+			<set name="slot">onehand</set>
+			<set name="damage" type="slashing">1d8</set>
+			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
+		</setters>
+	</element>
+</elements>

--- a/third-party/dnd-wiki/items/items-weapons.xml
+++ b/third-party/dnd-wiki/items/items-weapons.xml
@@ -20,10 +20,10 @@
 			<set name="slot">onehand</set>
 			<set name="damage" type="slashing">1d8</set>
 			<set name="versatile">1d10</set>
-			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
+			<set name="proficiency">ID_BREW_WEAPON_PROFICIENCY_KATANA</set>
 		</setters>
 	</element>
-	<element name="Finesse Katana" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_LIGHT_KATANA">
+	<element name="Katana, Finesse" type="Weapon" source="D&amp;D Wiki" id="ID_BREW_WEAPON_LIGHT_KATANA">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
 		<description>
 			<p></p>
@@ -34,7 +34,15 @@
 			<set name="weight" lb="2">2 lb.</set>
 			<set name="slot">onehand</set>
 			<set name="damage" type="slashing">1d8</set>
-			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_KATANA</set>
+			<set name="proficiency">ID_BREW_WEAPON_PROFICIENCY_KATANA</set>
 		</setters>
 	</element>
+	<element name="Weapon Proficiency (Katana)" type="Proficiency" source="D&amp;D Wiki" id="ID_BREW_WEAPON_PROFICIENCY_KATANA">
+		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_GROUP_SWORDS</supports>
+	</element>
+	<append id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_MELEE_WEAPONS">
+		<rules>
+			<grant type="Proficiency" id="ID_BREW_WEAPON_PROFICIENCY_KATANA" />
+		</rules>
+	</append>
 </elements>


### PR DESCRIPTION
https://www.dandwiki.com/wiki/Katana_(5e_Equipment)
• **Standard Katana**: analogue of Longsword.
• **Variant Katana**: Versatile property is replaced with Finesse property and weight is reduced to 2 lb.
• Both versions use one _Katana_ Proficiency.