### PR TITLE
Fix incomplete Silent Image description

### DIFF
--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -4,7 +4,7 @@
     <name>Spells</name>
     <description>Spells from the Player’s Handbook.</description>
     <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-    <update version="0.2.2">
+    <update version="0.2.3">
       <file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/spells.xml" />
     </update>
   </info>
@@ -6398,7 +6398,9 @@
   <element name="Silent Image" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_SILENT_IMAGE">
     <supports>Bard, Sorcerer, Wizard</supports>
     <description>
-      <p>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot cube. The image appears at a spot within range and lasts for the duration. The image is purely visual</p>
+      <p>You create the image of an object, a creature, or some other visible phenomenon that is no larger than a 15-foot cube. The image appears at a spot within range and lasts for the duration. The image is purely visual; it isn’t accompanied by sound, smell, or other sensory effects.</p>
+      <p class="indent">You can use your action to cause the image to move to any spot within range. As the image changes location, you can alter its appearance so that its movements appear natural for the image. For example, if you create an image of a creature and move it, you can alter the image so that it appears to be walking.</p>
+      <p class="indent">Physical interaction with the image reveals it to be an illusion, because things can pass through it. A creature that uses its action to examine the image can determine that it is an illusion with a successful Intelligence (Investigation) check against your spell save DC. If a creature discerns the illusion for what it is, the creature can see through the image.</p>
     </description>
     <setters>
       <set name="keywords"></set>


### PR DESCRIPTION
The description of the Silent Image spell was cut off for some reason. Here's the full version.