### PR TITLE
URL Update for WIKI Sorcerous Arcane Origin

### DIFF
--- a/third-party/dnd-wiki/classes/sorcerer-arcane-origin.xml
+++ b/third-party/dnd-wiki/classes/sorcerer-arcane-origin.xml
@@ -4,7 +4,7 @@
        <name>Arcane Sorcerous Origin</name>
        <description>5e homebrew</description>
        <author url="http://www.dandwiki.com/wiki/5e_Homebrew">D&amp;D Wiki</author>
-       <update version="0.0.1">
+       <update version="0.0.2">
            <file name="sorcerer-arcane-origin.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/classes/sorcerer-arcane-origin.xml" />
        </update>
     </info>
@@ -21,6 +21,9 @@
 		<sheet>
 			<description>Your innate abilities come from a deep connection with the fabric of magic.</description>
 		</sheet>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
 		<rules>
 			<grant type="Archetype Feature" id="ID_WIKI_ARCHETYPE_FEATURE_ARCANE_ORIGIN_MAGICAL_SECRETS" level="1" />
 			<grant type="Archetype Feature" id="ID_WIKI_ARCHETYPE_FEATURE_ARCANE_ORIGIN_EXTRA_SORCERY_POINTS" level="3" />
@@ -34,6 +37,9 @@
 			<p>At 1st level, your connection to the fabric of magic allows you to draw inspiration from many varieties of spellcasting. You learn two spells of your choice from any class. These spells count as sorcerer spells for you. A spell you choose must be of a level for which you have spell slots, or a cantrip. When you gain a level in this class, you can choose one spell gained from this ability and replace it with another spell from any class. You learn an additional spell from this feature at 4th, 9th, 14th and 20th level.</p>
 		</description>
 		<sheet display="false"/>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
 		<rules>
             <select type="Spell" name="Magical Secrets" supports="(0)||($(spellcasting:slots))" number="2" level="1" spellcasting="Sorcerer"/>
             <select type="Spell" name="Magical Secrets" supports="(0)||($(spellcasting:slots))" level="4" spellcasting="Sorcerer"/>
@@ -52,6 +58,9 @@
 			<description level="12">You gain 6 additional sorcery points.</description>
 			<description level="18">You gain 8 additional sorcery points.</description>
 		</sheet>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
         <rules>
             <stat name="sorcery-points" value="+2" level="3" />
             <stat name="sorcery-points" value="+2" level="6" />
@@ -66,6 +75,9 @@
 		<sheet>
 			<description>You can add your Charisma modifier (+$(Charisma Modifier)) to one damage roll of any cantrip you cast. When you cast a spell of 1st level or higher, you can spend a sorcery point to add your Charisma modifier (+$(Charisma Modifier)) to one damage roll, or one roll of the <i>color spray</i> or <i>sleep</i> spells. This can be used in conjunction with Metamagic effects.</description>
 		</sheet>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
         <rules>
             <select type="Class Feature" name="Metamagic (Powerful Spells)" supports="Metamagic" level="6"/>
         </rules>
@@ -77,6 +89,9 @@
 		<sheet>
 			<description>When you cast a spell of 1st level or higher, you can choose to spend 3 sorcery points and ignore the concentration requirement if it is a concentration spell, potentially allowing the effect to persist for its' maximum duration. All other aspects of the spell still apply, including range requirements and saving throws. You can only ever have one active effect in use with this ability, and if you cast another spell using this ability, the first spell immediately ends. Until you take a long rest, your maximum number of sorcery points available decreases by 3 for every time you use this ability.</description>
 		</sheet>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
 	</element>
 	<element name="Arcane Destruction" type="Archetype Feature" source="D&amp;D Wiki" id="ID_WIKI_ARCHETYPE_FEATURE_ARCANE_ORIGIN_ARCANE_DESTRUCTION">
 		<description>
@@ -85,5 +100,8 @@
 		<sheet>
 			<description>Whenever you roll for the damage dealt by a spell, you may spend any number of sorcery points to re-roll a number of damage die. Spending one sorcery point allows you to re-roll up to two damage die. You can re-roll the damage dice for ongoing effects, such as the <i>wall of fire</i> spell, when a creature takes damage from it, and from instantaneous effects at the time of casting.</description>
 		</sheet>
+      	<setters>
+        	<set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Arcane_Origin_(5e_Subclass)&amp;oldid=1086754</set>
+      	</setters>
 	</element>
 </elements>


### PR DESCRIPTION
• Links to specific features don't work, so i just used version page link for all features.