### PR TITLE
Fixes for Necromancer

### DIFF
--- a/third-party/dnd-wiki/classes/class-necromancer.xml
+++ b/third-party/dnd-wiki/classes/class-necromancer.xml
@@ -4,7 +4,7 @@
     <name>Necromancer</name>
     <description>The Necromancer class from the D&amp;D Wiki.</description>
         <author url="https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222">Kydo and BigShotFancyMan</author>
-    <update version="0.0.1">
+    <update version="0.0.2">
       <file name="class-necromancer.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/classes/class-necromancer.xml" />
     </update>
   </info>

--- a/third-party/dnd-wiki/classes/class-necromancer.xml
+++ b/third-party/dnd-wiki/classes/class-necromancer.xml
@@ -2,16 +2,16 @@
 <elements>
   <info>
     <name>Necromancer</name>
-    <description>The Necromancer class from the D&amp;DWiki.</description>
+    <description>The Necromancer class from the D&amp;D Wiki.</description>
         <author url="https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222">Kydo and BigShotFancyMan</author>
     <update version="0.0.1">
       <file name="class-necromancer.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki/classes/class-necromancer.xml" />
     </update>
   </info>
 
- <element name="Necromancer" type="Class" source="D&amp;DWiki" id="ID_WIKI_CLASS_NECROMANCER">
+ <element name="Necromancer" type="Class" source="D&amp;D Wiki" id="ID_WIKI_CLASS_NECROMANCER">
     <description>
-      <p>While others use magic to do paltry things like conjure fire or fly, the Necromancer is a master over deeath itself. They study the deep and forbidden secrets that raise the dead, controlling minions toward a variety of goals.  Perhaps they seek the power that mastery over death provides. Perhaps they are serious and unashamed scholars, who reject the small-minded boundaries held to by others. Each enemy they fell becomes an eager and disposable ally, they become immune to the energies of death and decay, and ultimately harness the immortality and power of undeath for themselves.</p>
+      <p>While others use magic to do paltry things like conjure fire or fly, the Necromancer is a master over death itself. They study the deep and forbidden secrets that raise the dead, controlling minions toward a variety of goals.  Perhaps they seek the power that mastery over death provides. Perhaps they are serious and unashamed scholars, who reject the small-minded boundaries held to by others. Each enemy they fell becomes an eager and disposable ally, they become immune to the energies of death and decay, and ultimately harness the immortality and power of undeath for themselves.</p>
       <h4>CREATING A NECROMANCER </h4>
       <p>A necromancer is a caster that is able to expel negative energies flowing through their veins. Necromancers are similar to sorcerers, but are more adept with necromancy and, to some extent, enchantment spells. They use their abilities to gain absolute control over their enemies' bodies, minds, and souls. Often the best way to do this is by raising/summoning undead from their fallen enemies; a skill at which they are unparalleled. Necromancers are also effective with diseases, poisons, and affecting opponents with fear, fatigue, exhaustion, pain, life drain, or even gaining mindless supporters through the use of enchantment magic to charm and dominate.</p>
       <p>A necromancer's strengths are in bolstering undead, summoning or raising undead minions (which they can control up to a number of a large mob) and being able to cast a vast repertoire of various necromancy spells. They are strong spell casters but are not durable in physical combat. A necromancer should primarily be used for crowd control, able to curse the enemy while animating different undead to occupy the enemy while their teammates continue to sustain a mass of dead bodies for you.</p>
@@ -98,7 +98,7 @@
       </rules>
     </multiclass>
   </element>
-  <element name="Spellcasting" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SPELLCASTING_NECROMANCER">
+  <element name="Spellcasting" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SPELLCASTING_NECROMANCER">
     <description>
       <p>You draw on the negative energy in the world to fuel your spells.</p>
       <h5>CANTRIPS</h5>
@@ -187,7 +187,7 @@
       <select type="Spell" name="Spell (Necromancer)" supports="$(spellcasting:list), $(spellcasting:slots)" level="20" number="2" spellcasting="Necromancer" />
     </rules>
   </element>
-  <element name="Life Tap" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_LIFE_TAP">
+  <element name="Life Tap" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_LIFE_TAP">
     <description>
       <p>Starting at 1st level, your touch can siphon the life force of others to bolster your own. As an action, you can make a melee spell attack against a living creature, dealing necrotic damage equal to 1d8 + your Charisma modifier on a hit. You gain temporary hit points equal to the amount of necrotic damage dealt. If this feature kills the creature, you gain twice as many temporary hit points from using this feature. The damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8). You may use this feature a number of times equal to your Charisma modifier(minimum one) and you regain all uses of this feature at the end of a long rest.</p>
     </description>
@@ -205,7 +205,7 @@
       <stat name="life tap:count" value="Charisma Modifier" bonus="life tap" />
     </rules>
   </element>
-  <element name="Necromancer Occult" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_NECROMANCER_OCCULT">
+  <element name="Necromancer Occult" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_NECROMANCER_OCCULT">
     <description>
       <p>At 2nd level, you choose an occult which specializes you in your dealings with death: Keeper, Reaper, and Undertaker, each of which is detailed at the end of the class description. Your occult grants you features when you choose it at 2nd level and additional features at 6th, 10th, and 14th level.</p>
     </description>
@@ -217,7 +217,7 @@
       <select type="Archetype" name="Necromancer Occult" supports="Necromancer Occult" />
     </rules>
   </element>
-  <element name="Soul Harvest" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SOUL_HARVEST">
+  <element name="Soul Harvest" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SOUL_HARVEST">
     <description>
       <p>Starting at 3rd level, by reaping life you are able to claim a fraction of those unfortunate creatures souls to regenerate your wounds and fortify your body. At the end of your turn, if you or any undead under your control have killed one or more creatures, you gain hit points equal to your necromancer level. If doing so would grant you more hit points than you can have, you gain temporary hit points equal to the amount of excess hit points received.</p>
     </description>
@@ -228,7 +228,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Soul_Harvest</set>
     </setters>
   </element>
-  <element name="Ability Score Improvement (Necromancer)" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_ABILITYSCOREIMPROVEMENT_NECROMANCER">
+  <element name="Ability Score Improvement (Necromancer)" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_ABILITYSCOREIMPROVEMENT_NECROMANCER">
     <description>
       <p>When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can’t increase an ability score above 20 using this feature.</p>
     </description>
@@ -249,7 +249,7 @@
       <select type="Class Feature" name="Improvement Option (Necromancer 19)" supports="Improvement Option,Necromancer,19" level="19" />
     </rules>
   </element>
-  <element name="Spontaneous Unburial" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SPONTANEOUS_UNBURIAL">
+  <element name="Spontaneous Unburial" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SPONTANEOUS_UNBURIAL">
     <description>
       <p>Starting at 5th level, your understanding of necrotic and negative energies allows you to raise the dead with ease. You may cast the spell <i>animate dead</i> as an action and you do not require a corpse or pile of bones to do so; the skeleton or zombie will claw its way up from underground and acts on your next turn. In addition, you learn the spell <i>animate dead</i>. This spell does not count against your number of spells known.</p>
     </description>
@@ -263,7 +263,7 @@
       <grant type="Spell" id="ID_PHB_SPELL_ANIMATE_DEAD" spellcasting="Necromancer"/>
     </rules>
   </element>
-  <element name="Animate Major Undead" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_ANIMATE_MAJOR_UNDEAD">
+  <element name="Animate Major Undead" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_ANIMATE_MAJOR_UNDEAD">
     <description>
       <p>Beginning at 7th level, your pursuit of knowledge has led to uncover the secrets to mastering undead of all sizes. You can now raise any corpse that is Huge or smaller of a monstrosity, humanoid, or beast with challenge rating 3 or lower can be animated. It keeps its original abilities and attacks, but loses any resistances, immunities, legendary actions, senses it had and gains the immunities and vulnerabilities of its type, skeleton or zombie. You can issue mental commands to the creature as the <i>animate dead</i> spell. You can only control one major undead at a time. This feature functions as the spell <i>animate dead</i> except where otherwise noted. You may use this feature on an existing undead you control to reassert your control over it. You must finish a long rest before you can use this feature again.</p>
       <p class="indent">At level 11, you may animate a monstrosity, humanoid or beast with a challenge rating of 6 or lower.</p>
@@ -278,7 +278,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Animate_Major_Undead</set>
     </setters>
   </element>
-  <element name="Ritualistic Unburial" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_RITUALISTIC_UNBURIAL">
+  <element name="Ritualistic Unburial" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_RITUALISTIC_UNBURIAL">
     <description>
       <p>At level 14th level, the repetitive nature of raising your undead has become like a ritual for you. You may cast <i>animate dead</i> as a ritual.</p>
     </description>
@@ -289,7 +289,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Ritualistic_Unburial</set>
     </setters>
   </element>
-  <element name="Macabre" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_MACABRE">
+  <element name="Macabre" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_MACABRE">
     <description>
       <p>Starting at 18th level, the death you surround yourself with has become part of you. Your flesh has become pale and your eyes have taken on a yellow tint. Some necromancers alter their appearance with stitches sewn on their face, body, legs, or arms. Others may adorn the remains of corpses to impose fear and keep people away. The overexposure to death has earned an affinity with undead. Whenever you interact with undead, you have advantage on all Charisma checks. In addition, while you may look sick and exhausted from the constant dealings with death, you do not age and you are immune to poison damage, diseases, exhuastion, as well as the frightened and poisoned conditions. </p>
     </description>
@@ -300,7 +300,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Macabre</set>
     </setters>
   </element>
-  <element name="Séance" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SEANCE">
+  <element name="Séance" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_SEANCE">
     <description>
       <p>Starting at 20th level, your presence commands respect from undead. At will, the necromancer can target one undead creature they can see within 30 feet of them. The target must make a Wisdom saving throw. On a failed save, the target must obey the necromancer's commands for the next 24 hours, or until the necromancer uses Séance again. A necromancer can only control a single undead creature with this feature.</p>
     </description>
@@ -312,7 +312,7 @@
     </setters>
   </element>
   <!-- VARIANT FEATURE: GRIM HARVEST -->
-  <element name="Grim Harvest" type="Class Feature" source="D&amp;DWiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_GRIM_HARVEST">
+  <element name="Grim Harvest" type="Class Feature" source="D&amp;D Wiki" id="ID_WIKI_CLASS_FEATURE_NECROMANCER_GRIM_HARVEST">
     <supports>Necromancer Variant Feature</supports>
     <description>
       <p>Starting at 20th level, the area around you becomes a volatile zone of death and necrotic magic. You have learned to sew the agony of the newly departed's death into those nearby. Whenever an enemy creature dies within 60 feet of the you, you may use your reaction to target it and cause an explosion of necrotic energy. Choose any number of creatures within 10 feet of the explosion to make a Constitution saving throw. On a failed save, they take 8d6 necrotic damage and half as much on a success. If this damage kills any creatures, you may target one of the creatures killed to cause a secondary explosion but the damage is reduced to 4d6 and halved on a successful Constitution saving throw. If this secondary explosion kills any creatures, you may choose one of the creatures killed by this secondary damage to cause an explosion a third time but the damage is reduced to 2d6 or no damage on a successful Constitution saving throw. Any undead you control within the radius of the explosions regain hit points equal to half the amount of necrotic damage done. You regain use of this feature when you complete a short or long rest. </p>
@@ -326,7 +326,7 @@
   </element>
 
   <!-- NECROMANCER OCCULT: KEEPER -->
-  <element name="Keeper" type="Archetype" source="D&amp;DWiki"  id="ID_WIKI_ARCHETYPE_NECROMANCER_KEEPER">
+  <element name="Keeper" type="Archetype" source="D&amp;D Wiki"  id="ID_WIKI_ARCHETYPE_NECROMANCER_KEEPER">
     <supports>Necromancer Occult</supports>
     <description>
       <p>An eager doctor's assistant stays late after a failed surgery to stitch the cadaver closed, and prepare it for transport to the undertaker. But while he has the remains here to himself, he sees no harm in a little research. This case was an odd one, and he'd like to know more about it. As he conducts his experiments, he murmurs to the body, "Let's see where it all went wrong, and where we can do better next time."</p>
@@ -349,7 +349,7 @@
       <grant type="Archetype Feature"   name="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_REFUSAL" level="14"/>
     </rules>
   </element>
-  <element name="Life on Demand" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_LIFE_ON_DEMAND">
+  <element name="Life on Demand" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_LIFE_ON_DEMAND">
     <description>
       <p>Beginning at 2nd level, you can accelerate the body's natural healing when it is needed the most. As an action, a creature you touch can expand a number of its hit dice equal to your spellcasting modifier (minimum of 1) to regain hit points. After you use this feature, you must finish a short or long rest.</p>
       <p class="indent">At 5th level, a creature can also add it's Constitution modifier to hit points recovered this way.</p>
@@ -364,7 +364,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Life_on_Demand</set>
     </setters>
   </element>
-  <element name="Expanded Intellect" type="Archetype Feature" source="D&amp;DWiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_EXPANDED_INTELLECT">
+  <element name="Expanded Intellect" type="Archetype Feature" source="D&amp;D Wiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_EXPANDED_INTELLECT">
     <description>
       <p>Beginning at 6th level, your studies of death and undeath have opened up new possibilities for you. You gain the <i>spare the dying</i> cantrip.</p>
       <p class="indent">You also add the following spells to your list of spells to learn from: <i>cure wounds, lesser restoration, beacon of hope, feign death, revivify, death ward, greater restoration, resurrection,</i> and <i>mass heal</i>.</p>
@@ -388,7 +388,7 @@
       <grant type="Spell" id="ID_PHB_SPELL_SPARE_THE_DYING" spellcasting="Necromancer"/>
     </rules>
   </element>
-  <element name="Aura of Wellbeing" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_AURA_OF_WELLBEING">
+  <element name="Aura of Wellbeing" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_AURA_OF_WELLBEING">
     <description>
       <p>Beginning at 10th level, you emanate an aura that rejuvenates and prolongs the life of others around you. If an allied creature begins its turn within 10 feet of you, it gains hit points equal to your proficiency bonus if its hit points are below half its hit point maximum.</p>
     </description>
@@ -399,7 +399,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Aura_of_Wellbeing</set>
     </setters>
   </element>
-  <element name="Refusal" type="Archetype Feature" source="D&amp;DWiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_REFUSAL">
+  <element name="Refusal" type="Archetype Feature" source="D&amp;D Wiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_KEEPER_REFUSAL">
     <description>
       <p>Beginning at 14th level, you can decide to ignore death if it's too inconvenient. If a creature within 5 feet of you that you can touch (including you) drops to 0 hit points, you may use your reaction to cause that creature to drop to 1 hit point instead. You must finish a short or long rest before you can use this feature again.</p>
     </description>
@@ -412,7 +412,7 @@
   </element>
 
   <!-- NECROMANCER OCCULT: REAPER -->
-  <element name="Reaper" type="Archetype" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_NECROMANCER_REAPER">
+  <element name="Reaper" type="Archetype" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_NECROMANCER_REAPER">
     <supports>Necromancer Occult</supports>
     <description>
       <p>The village is quiet during the strangers walk down the roads. No birds are chirping, no children heard playing, no wind blowing. He bends over to grab a flower but it withers before even touched. Death consumes this man. Death consumed the village.</p>
@@ -435,7 +435,7 @@
       <grant type="Archetype Feature"   name="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_GRIM" level="14"/>
     </rules>
   </element>
-  <element name="Death's Knowledge" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_DEATHS_KNOWLEDGE">
+  <element name="Death's Knowledge" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_DEATHS_KNOWLEDGE">
     <description>
       <p>Beginning at 2nd level, some ancient tomes, spell books, or scrolls have provided knowledge to you. Add the following spells to your necromancer spell list: <i>inflict wounds, revivify, speak with dead, commune with dead, raise dead, resurrection,</i> and <i>true resurrection</i>.</p>
       <p class="indent">At 5th level, you may add three spells from any class spell list for which you can cast to your necromancer spell list.</p>
@@ -457,7 +457,7 @@
       <select type="Spell" name="Death's Knowledge" supports="(0)||($(spellcasting:slots))" number="3" level="5" spellcasting="Necromancer"/>
     </rules>
   </element>
-  <element name="Improved Soul Harvest" type="Archetype Feature" source="D&amp;DWiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_IMPROVED_SOUL_HARVEST">
+  <element name="Improved Soul Harvest" type="Archetype Feature" source="D&amp;D Wiki"  id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_IMPROVED_SOUL_HARVEST">
     <description>
       <p>Starting at 6th level, you've gained the knowledge to channel the souls you harvest into your spells. You may store a number of souls equal to your necromancer level from killing creatures with soul harvest for later use. You can consume souls to regain up to a 3rd level spell slot, which costs 2 souls for 1st level spell and every additional spell level beyond. For instance, a 3rd level spell would consume 6 souls. In addition, when you deal damage to a creature with a spell, you may consume any number of souls in your possession to deal additional necrotic damage equal to the number of souls you consume. </p>
     </description>
@@ -468,7 +468,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Improved_Soul_Harvest</set>
     </setters>
   </element>
-  <element name="Necrosis Spellcasting" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_NECROSIS_SPELLCASTING">
+  <element name="Necrosis Spellcasting" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_NECROSIS_SPELLCASTING">
     <description>
       <p>Starting at 10th level, a cloud of stench accompanies the spells that you cast, eating away at the flesh and bone of your victim and distracting them. Any necromancy spells that you cast deal an additional 1d8 necrotic damage.</p>
       <p class="indent">In addition, undead have disadvantage on saving throws against your spells and class features.</p>
@@ -480,7 +480,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Necrosis_Spellcasting</set>
     </setters>
   </element>
-  <element name="Grim" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_GRIM">
+  <element name="Grim" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_REAPER_GRIM">
     <description>
       <p>Beginning at 14th level, stories of something supernatural taking lives comes to fruition. Fairy tales depict a Grim Reaper that comes to take souls of people ready to die, but the truth is, the Grim Reaper visits to deal death. An aura surrounds you and saps the life of anything within 5 feet of you. If a creature ends its turn within range it must succeed on a Constitution saving throw or lose hit points equal to the number of souls you have stored. You gain hit points equal to half the hit points the creature lost, rounded up.</p>
     </description>
@@ -493,7 +493,7 @@
   </element>
 
   <!-- NECROMANCER OCCULT: UNDERTAKER -->
-  <element name="Undertaker" type="Archetype" source="D&amp;DWiki"  id="ID_WIKI_ARCHETYPE_NECROMANCER_UNDERTAKER">
+  <element name="Undertaker" type="Archetype" source="D&amp;D Wiki"  id="ID_WIKI_ARCHETYPE_NECROMANCER_UNDERTAKER">
     <supports>Necromancer Occult</supports>
     <description>
       <p>In a cemetery, a woman provides a service for a family grieving their lost one. She had spent the evening before prepping the corpse and making everything presentable for the wake. Her services were appreciated and she accepted her thanks, but her real joy would happen after everyone left. She looks at her next corpse, the shopkeep of the funeral home, "Why let the dead rot?"</p>
@@ -516,7 +516,7 @@
       <grant type="Archetype Feature" name="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_LORD_OF_THE_UNDEAD"   level="14"/>
     </rules>
   </element>
-  <element name="Unholy Resistance" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_UNHOLY_RESISTANCE">
+  <element name="Unholy Resistance" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_UNHOLY_RESISTANCE">
     <description>
       <p>Beginning at 2nd level, the time you've spent wielding negative energy has made itself a part of you. You have resistance to necrotic damage and your hit point maximum cannot be reduced.</p>
       <p class="indent">At 5th level, this feature extends to any undead under your control.</p>
@@ -532,7 +532,7 @@
       <stat name="resistance:necrotic">
     </rules> -->
   </element>
-  <element name="Improved Animate Undead" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_IMPROVED_ANIMATE_UNDEAD">
+  <element name="Improved Animate Undead" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_IMPROVED_ANIMATE_UNDEAD">
     <description>
       <p>Beginning at 6th level, the negative energy you use to summon your undead is fortified within them. Skeletons and zombies you raise have additional hit points and bonuses to their melee attack rolls equal to your proficiency bonus. In addition, whenever you cast a spell or use a feature or item to raise undead, you raise one additional skeleton or zombie.</p>
     </description>
@@ -543,7 +543,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Improved_Animate_Undead</set>
     </setters>
   </element>
-  <element name="Undead Resolve" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_UNDEAD_RESOLVE">
+  <element name="Undead Resolve" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_UNDEAD_RESOLVE">
     <description>
       <p>Beginning at 10th level, your bond with the dead has strengthened their resolve against that which is holy. Undead you control have advantage on Wisdom saving throws against Turn Undead attempts. In addition, undead you raise add your proficiency bonus to their Armor Class.</p>
     </description>
@@ -554,7 +554,7 @@
       <set name="sourceUrl">https://www.dandwiki.com/w/index.php?title=Necromancer_(5e_Class)&amp;oldid=1134222#Undead_Resolve</set>
     </setters>
   </element>
-  <element name="Lord of the Undead" type="Archetype Feature" source="D&amp;DWiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_LORD_OF_THE_UNDEAD">
+  <element name="Lord of the Undead" type="Archetype Feature" source="D&amp;D Wiki"   id="ID_WIKI_ARCHETYPE_FEATURE_NECROMANCER_UNDERTAKER_LORD_OF_THE_UNDEAD">
     <description>
       <p>Beginning at 14th level, you've reached the epitome of raising undead. Your undead creatures no longer have a damage vulnerability and gain additional hit points equal to your necromancer level. </p>
     </description>


### PR DESCRIPTION
• Fixed D&D Wiki Source
• Fixed "deeath" typo