### PR TITLE
UA 20171113: Elf Subraces

### DIFF
--- a/core/players-handbook/races/race-elf.xml
+++ b/core/players-handbook/races/race-elf.xml
@@ -68,7 +68,7 @@
       <stat name="Speed" value="+30" bonus="base" />
       <grant type="Size" name="ID_SIZE_MEDIUM" />
       <grant type="Vision" name="ID_VISION_DARKVISION" />
-      <grant type="Language" name="ID_LANGUAGE_COMMON" />
+      <grant type="Language" name="ID_LANGUAGE_COMMON" requirements="!ID_WOTC_UA20171113_SUB_RACE_GRUGACH" />
       <grant type="Language" name="ID_LANGUAGE_ELVISH" />
       <grant type="Racial Trait" name="ID_RACIAL_TRAIT_KEEN_SENSES" />
       <grant type="Racial Trait" name="ID_RACIAL_TRAIT_FEY_ANCESTRY" />

--- a/core/players-handbook/races/race-elf.xml
+++ b/core/players-handbook/races/race-elf.xml
@@ -4,7 +4,7 @@
 		<name>Elf</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.1.5">
+		<update version="0.1.6">
 			<file name="race-elf.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/races/race-elf.xml" />
 		</update>
 	</info>

--- a/unearthed-arcana.index
+++ b/unearthed-arcana.index
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana</name>
 		<description>The material presented in Unearthed Arcana will range from mechanics that we expect one day to publish in a supplement to house rules from our home campaigns that we want to share, from core system options to setting-specific material. Once it’s out there, you can expect us to check in with you to see how it’s working out and what we can do to improve it.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana">Wizards of the Coast</author>
-		<update version="0.4.3">
+		<update version="0.4.4">
 			<file name="unearthed-arcana.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana.index" />
 		</update>
 	</info>

--- a/unearthed-arcana.index
+++ b/unearthed-arcana.index
@@ -67,7 +67,7 @@
 		<!--<file name="20170807.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20170807.xml" />-->
 		<!--<file name="20170911.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20170911.xml" />-->
 		<file name="20171009.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20171009.xml" />
-		<!--<file name="20171113.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20171113.xml" />-->
+		<file name="20171113.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20171113.xml" />
 
 		<!-- 2018 -->
 		<file name="20180108.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2018/20180108.xml" />

--- a/unearthed-arcana/2017/20171113.xml
+++ b/unearthed-arcana/2017/20171113.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+        <name>Unearthed Arcana: Elf Subraces</name>
+        <description>When you choose the subrace of your elf character, you can choose one of the following options, in addition to those in the <i>Player’s Handbook</i>.</description>
+        <author url="http://dnd.wizards.com/articles/unearthed-arcana/elf-subraces">Wizards of the Coast</author>
+        <update version="0.0.4">
+            <file name="20171113.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20171113.xml" />
+        </update>
+    </info>
+
+	<element name="Unearthed Arcana: Elf Subraces" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20171113">
+		<description>
+			<p>When you choose the subrace of your elf character, you can choose one of the following options, in addition to those in the <i>Player’s Handbook</i>.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20171113</set>
+			<set name="url">http://dnd.wizards.com/articles/unearthed-arcana/elf-subraces</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20171113</set>
+		</setters>
+	</element>
+
+    <element name="Avariel" type="Sub Race" source="Unearthed Arcana: Elf Subraces" id="ID_WOTC_UA20171113_SUB_RACE_AVARIEL">
+    	<supports>Elf</supports>
+    	<requirements />
+    	<description>
+      		<p>The avariel are winged elves. These rare creatures were more common when the worlds of the multiverse were young, but frequent conflicts with dragons much reduced the winged elves’ number. Still, a few colonies persist here and there in the Material Plane and on the Plane of Air.</p>
+      		<p>
+        		<span class="feature">Flight.</span>You have a flying speed of 30 feet. To use this speed, you can't be wearing medium or heavy armor.<br />
+        		<span class="feature">Languages.</span>You can speak, read, and write Auran.<br />
+      		</p>
+    	</description>
+    	<sheet display="false" />
+    	<setters>
+      		<set name="height" modifier="2d10">4'8"</set>
+      		<set name="weight" modifier="1d4">90 lb.</set>
+    	</setters>
+    	<rules>
+      		<stat name="speed:fly" value="30" />
+			<grant type="Language" id="ID_MM_LANGUAGE_AURAN" />
+    	</rules>
+  	</element>  
+    <element name="Grugach" type="Sub Race" source="Unearthed Arcana: Elf Subraces" id="ID_WOTC_UA20171113_SUB_RACE_GRUGACH">
+    	<supports>Elf</supports>
+    	<requirements />
+    	<description>
+      		<p>The grugach of the world of Greyhawk shun contact with other folk, preferring the solace of the deepest forests and the companionship of wild animals. Even other elves draw their suspicion.</p>
+      		<p class="indent">The grugach tend toward chaos and neutrality. They feel no special duty to anyone beyond their own folk and the forest that is their home. Troubles beyond their borders are best kept there. At the same time, they harbor little ambition beyond a peaceful coexistence with nature.</p>
+      		<p class="indent">If anyone is fool enough to disturb a grugach realm, these elves take to arms and fight in earnest. Grugach master the basic weapons needed to hunt and forage in the wood. Every copse of trees becomes a sniper’s nest,and each forest meadow is an ambush point. The grugach set pits filled with stakes, snares that leave an intruder helpless to grugach arrows, and other snares designed to kill rather than capture. The grugach fight to the death to preserve their realms.</p>
+      		<p>
+        		<span class="feature">Ability Score Increase.</span>Your Strength score increases by 1.<br />
+        		<span class="feature">Grugach Weapon Training.</span>You have proficiency with the spear, shortbow, longbow and net.<br />
+        		<span class="feature">Cantrip.</span>You know one cantrip of your choice from the druid spell list. Wisdom is your spellcasting ability for it.<br />
+        		<span class="feature">Languages.</span>Unlike other elves, you don’t speak, read, or write Common. You instead speak, read, and write Sylvan.<br />
+      		</p>
+    	</description>
+    	<sheet display="false" />
+    	<setters>
+      		<set name="height" modifier="2d6">4'5"</set>
+      		<set name="weight" modifier="1d6">75 lb.</set>
+    	</setters>
+    	<rules>
+      		<stat name="Strength" value="+1" />
+      		<grant name="ID_WOTC_UA20171113_RACIAL_TRAIT_GRUGACH_WEAPON_TRAINING" type="Racial Trait" />
+      		<select type="Spell" name="Cantrip (Grugach)" supports="Druid,0" spellcasting="Druid" />
+			<grant type="Language" id="ID_LANGUAGE_SYLVAN" />
+    	</rules>
+  	</element>
+    <element name="Grugach Weapon Training" type="Racial Trait" source="Unearthed Arcana: Elf Subraces" id="ID_WOTC_UA20171113_RACIAL_TRAIT_GRUGACH_WEAPON_TRAINING">
+    	<description>
+      		<p>You have proficiency with the spear, shortbow, longbow and net.</p>
+    	</description>
+    	<sheet display="false" />
+    	<rules>
+			<grant type="Proficiency" name="ID_PROFICIENCY_WEAPON_PROFICIENCY_SPEAR" />
+			<grant type="Proficiency" name="ID_PROFICIENCY_WEAPON_PROFICIENCY_SHORTBOW" />
+			<grant type="Proficiency" name="ID_PROFICIENCY_WEAPON_PROFICIENCY_LONGBOW" />
+			<grant type="Proficiency" name="ID_PROFICIENCY_WEAPON_PROFICIENCY_NET" />
+    	</rules>
+  	</element>
+</elements>

--- a/unearthed-arcana/2017/20171113.xml
+++ b/unearthed-arcana/2017/20171113.xml
@@ -4,7 +4,7 @@
         <name>Unearthed Arcana: Elf Subraces</name>
         <description>When you choose the subrace of your elf character, you can choose one of the following options, in addition to those in the <i>Player’s Handbook</i>.</description>
         <author url="http://dnd.wizards.com/articles/unearthed-arcana/elf-subraces">Wizards of the Coast</author>
-        <update version="0.0.4">
+        <update version="0.0.1">
             <file name="20171113.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20171113.xml" />
         </update>
     </info>

--- a/unearthed-arcana/2017/20171113.xml
+++ b/unearthed-arcana/2017/20171113.xml
@@ -39,8 +39,8 @@
       		<set name="weight" modifier="1d4">90 lb.</set>
     	</setters>
     	<rules>
-      		<stat name="speed:fly" value="30" />
-			<grant type="Language" id="ID_MM_LANGUAGE_AURAN" />
+      		<stat name="speed:fly" value="30" equipped="![armor:medium]||![armor:heavy]" />
+		<grant type="Language" id="ID_MM_LANGUAGE_AURAN" />
     	</rules>
   	</element>  
     <element name="Grugach" type="Sub Race" source="Unearthed Arcana: Elf Subraces" id="ID_WOTC_UA20171113_SUB_RACE_GRUGACH">
@@ -65,7 +65,7 @@
     	<rules>
       		<stat name="Strength" value="+1" />
       		<grant name="ID_WOTC_UA20171113_RACIAL_TRAIT_GRUGACH_WEAPON_TRAINING" type="Racial Trait" />
-      		<select type="Spell" name="Cantrip (Grugach)" supports="Druid,0" spellcasting="Druid" />
+      		<select type="Spell" name="Cantrip (Grugach)" supports="Druid,0" />
 			<grant type="Language" id="ID_LANGUAGE_SYLVAN" />
     	</rules>
   	</element>


### PR DESCRIPTION
• Includes Avariel and Grugach Subraces
• Common Language for Elves now requires to not be Grugash Subrace