### PR TITLE
Weapon Master Feat: Selection Fix

### DIFF
--- a/core/players-handbook/feats.xml
+++ b/core/players-handbook/feats.xml
@@ -4,7 +4,7 @@
     <name>Feats</name>
     <description>Feats from the Player’s Handbook.</description>
     <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-    <update version="0.0.9">
+    <update version="0.1.0">
       <file name="feats.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/feats.xml" />
     </update>
   </info>
@@ -1083,7 +1083,7 @@
     </sheet>
     <rules>
       <select type="Ability Score Improvement" name="Ability Score Increase (Weapon Master)" supports="ID_PHB_FEAT_ASI_STRENGTH|ID_PHB_FEAT_ASI_DEXTERITY" />
-      <select type="Proficiency" name="Weapon Master" supports="Weapon" number="4"/>
+      <select type="Proficiency" name="Weapon Master" supports="ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE||ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_RANGED||ID_INTERNAL_WEAPON_CATEGORY_SIMPLE_MELEE||ID_INTERNAL_WEAPON_CATEGORY_SIMPLE_RANGED" number="4"/>
     </rules>
   </element>
 


### PR DESCRIPTION
Now Weapon Master Feat will give Proficiency selections for non-Core weapons