### PR TITLE
Artificer: Fix for Alchemical Formulas

### DIFF
--- a/unearthed-arcana/2017/20170109.xml
+++ b/unearthed-arcana/2017/20170109.xml
@@ -4,7 +4,7 @@
         <name>Unearthed Arcana: Artificer</name>
         <description>Makers of magic-infused objects, artificers are defined by their inventive nature.</description>
         <author url="http://dnd.wizards.com/articles/unearthed-arcana/artificer">Wizards of the Coast</author>
-        <update version="0.0.9">
+        <update version="0.1.0">
             <file name="20170109.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20170109.xml" />
         </update>
     </info>
@@ -390,7 +390,7 @@
     <!-- Alchemical Formulas -->
     <element name="Alchemical Fire" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_ALCHEMICAL_FIRE">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel, pull out a vial of volatile liquid, and hurl the vial at a creature, object, or surface within 30 feet of you (the vial and its contents disappear if you don't hurl the vial by the end of the current turn). On impact, the vial detonates in a 5-foot radius. Any creature in that area must succeed on a Dexterity saving throw or take 1d6 fire damage.</p>
             <p class="indent">This formula's damage increases by 1d6 when you reach certain levels in this class: 4th level (2d6), 7th level (3d6), 10th level (4d6), 13th level (5d6), 16th level (6d6), and 19th level (7d6).</p>
@@ -412,7 +412,7 @@
     </element>
     <element name="Alchemical Acid" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_ALCHEMICAL_ACID">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel, pull out a vial of acid, and hurl the vial at a creature or object within 30 feet of you (the vial and its contents disappear if you don't hurl the vial by the end of the current turn). The vial shatters on impact. A creature must succeed on a Dexterity saving throw or take 1d6 acid damage. An object automatically takes that damage, and the damage is maximized.</p>
             <p class="indent">This formula's damage increases by 1d6 when you reach certain levels in this class: 3rd level (2d6), 5th level (3d6), 7th level (4d6), 9th level (5d6), 11th level (6d6), 13th level (7d6), 15th level (8d6), 17th level (9d6), and 19th level (10d6).</p>
@@ -434,7 +434,7 @@
     </element>
     <element name="Healing Draught" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_HEALING_DRAUGHT">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel and pull out a vial of healing liquid. A creature can drink it as an action to regain 1d8 hit points. The vial then disappears. Once a creature regains hit points from this alchemical formula, the creature can't do so again until it finishes a long rest. If not used, the vial and its contents disappear after 1 hour. While the vial exists, you can't use this formula.</p>
             <p class="indent">This formula's healing increases by 1d8 when you reach certain levels in this class: 3rd level (2d8), 5th level (3d8), 7th level (4d8), 9th level (5d8), 11th level (6d8), 13th level (7d8), 15th level (8d8), 17th level (9d8), and 19th level (10d8).</p>
@@ -456,7 +456,7 @@
     </element>
     <element name="Smoke Stick" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_SMOKE_STICK">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel and pull out a stick that produces a thick plume of smoke. You can hold on to the stick or throw it to a point up to 30 feet away as part of the action used to produce it. The area in a 10-foot radius around the stick is filled with thick smoke that blocks vision, including darkvision. The stick and smoke persist for 1 minute and then disappear. After using this formula, you can't do so again for 1 minute.</p>
         </description>
@@ -477,7 +477,7 @@
     </element>
     <element name="Swift Step Draught" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_SWIFT_STEP_DRAUGHT">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As a bonus action, you can reach into your Alchemist's Satchel and pull out a vial filled with a bubbling, brown liquid. As an action, a creature can drink it. Doing so increases the creature's speed by 20 feet for 1 minute, and the vial disappears. If not used, the vial and its contents disappear after 1 minute. After using this formula, you can't do so again for 1 minute.</p>
         </description>
@@ -498,7 +498,7 @@
     </element>
     <element name="Tanglefoot Bag" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_TANGLEFOOT_BAG">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel and pull out a bag filled with writhing, sticky black tar and hurl it at a point on the ground within 30 feet of you (the bag and its contents disappear if you don't hurl the bag by the end of the current turn). The bag bursts on impact and covers the ground in a 5-foot radius with sticky goo. That area becomes difficult terrain for 1 minute, and any creature that starts its turn on the ground in that area has its speed halved for that turn. After using this formula, you can't do so again for 1 minute.</p>
         </description>
@@ -519,7 +519,7 @@
     </element>
     <element name="Thunderstone" type="Spell" source="Unearthed Arcana: Artificer" id="ID_WOTC_UA_SPELL_THUNDERSTONE">
         <supports>Alchemical Formula</supports>
-		<requirements>ID_WOTC_UA_CLASS_ARTIFICER</requirements>
+		<requirements>ID_WOTC_UA_CLASS_ARTIFICER||ID_WOTC_UA_MULTICLASS_ARTIFICER</requirements>
         <description>
             <p>As an action, you can reach into your Alchemist's Satchel and pull out a crystalline shard and hurl it at a creature, object, or surface within 30 feet of you (the shard disappears if you don't hurl it by the end of the current turn). The shard shatters on impact with a blast of concussive energy. Each creature within 10 feet of the point of impact must succeed on a Constitution saving throw or be knocked prone and pushed 10 feet away from that point.</p>
         </description>


### PR DESCRIPTION
• Alchemical Formulas are now selectable when multiclassing in Artificer.