### PR TITLE
Typo Corrections and text replacement

### DIFF
--- a/supplements/volos-guide-to-monsters/race-aasimar.xml
+++ b/supplements/volos-guide-to-monsters/race-aasimar.xml
@@ -19,11 +19,11 @@
         <p>While aasimar are strident foes of evil, they typically prefer to keep a low profile. An aasimar inevitably draws the attention of evil cultists, fiends, and other enemies of good, all of whom would be eager to strike down a celestial champion if they had the chance.</p>
         <p class="indent">When traveling, aasimar prefer hoods, closed helms, and other gear that allows them to conceal their identities. They nevertheless have no compunction about striking openly at evil. The secrecy they desire is never worth endangering the innocent.</p>
         <h4>AASIMAR GUIDES</h4>
-        <p>An aasimar, except for one who has turned to evil, has a link to an angelic being. That being- usually a devaprovides guidance to the aasimar, though this connection functions only in dreams. As such, the guidance is not a direct command or a simple spoken word. Instead, the aasimar receives visions, prophecies, and feelings.</p>
+        <p>An aasimar, except for one who has turned to evil, has a link to an angelic being. That being-usually a deva-provides guidance to the aasimar, though this connection functions only in dreams. As such, the guidance is not a direct command or a simple spoken word. Instead, the aasimar receives visions, prophecies, and feelings.</p>
         <p class="indent">The angelic being is far from omniscient. Its guidance is based on its understanding of the tenets of law and good, and it might have insight into combating especially powerful evils that it knows about.</p>
         <p class="indent">As part of fleshing out an aasimar character, consider the nature of that character's angelic guide. The Angelic Guide tables offer names and natures that you can use to flesh out your character's guide.</p>
         <h4>CONFLICTED SOULS</h4>
-        <p>Despite its celestial origin, an aasimar is mortal and possesses free will. Most aasimar follow their ordained path, but some grow to see their abilities as a curse. These disaffected aasimar are typically content to turn away frorri the world, but a few become agents of evil. In their minds, their exposure to celestial powers amounted to little more than brainwashing.</p>
+        <p>Despite its celestial origin, an aasimar is mortal and possesses free will. Most aasimar follow their ordained path, but some grow to see their abilities as a curse. These disaffected aasimar are typically content to turn away from the world, but a few become agents of evil. In their minds, their exposure to celestial powers amounted to little more than brainwashing.</p>
         <p class="indent">Evil aasimar make deadly foes. The radiant power they once commanded becomes corrupted into a horrid, draining magic. And their angelic guides abandon them.</p>
         <p class="indent">Even aasimar wholly dedicated to good sometimes feel torn between two worlds. The angels that guide them see the world from a distant perch. An aasimar who wishes to stop and help a town recover from a drought might be told by an angelic guide to push forward on a greater quest. To a distant angel, saving a few commoners might pale in comparison to defeating a cult of Orcus. An aasimar's guide is wise but not infallible.</p>
         <h4>AASIMAR TRAITS</h4>
@@ -33,7 +33,7 @@
           <span class="feature">Alignment.</span>Imbued with celestial power, most aasimar are good. Outcast aasimar are most often neutral or even evil.<br />
           <span class="feature">Size.</span>Aasimar have the same range of height and weight as humans.<br />
           <span class="feature">Speed.</span>Your base walking speed is 30 feet.<br />        
-          <span class="feature">Dark Vision.</span>Blessed with a radiant soul, your vision can easily cut through darkness. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.<br />
+          <span class="feature">Darkvision.</span>Blessed with a radiant soul, your vision can easily cut through darkness. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray.<br />
           <span class="feature">Celestial Resistance.</span>You have resistance to necrotic damage and radiant damage.<br />
           <span class="feature">Healing Hands.</span>As an action, you can touch a creature and cause it to regain a number of hit points equal to your level. Once you use this trait, you can't use it again until you finish a long rest.<br />
           <span class="feature">Light Bearer.</span>You know the light cantrip. Charisma is your spellcasting ability for it.<br />
@@ -112,7 +112,7 @@
   <element name="Protector Aasimar" type="Sub Race" source="Volo’s Guide to Monsters" id="ID_WOTC_VGTM_SUB_RACE_PROTECTOR_AASIMAR">
     <supports>Aasimar</supports>
     <description>
-      <p>Protector aasimar are charged by the powers of good to guard the weak, to strike at evil wher,ever it arises, and to stand vigilant against the darkness. From a young age, a protector aasimar receives advice and directives that urge to stand against evil.</p>
+      <p>Protector aasimar are charged by the powers of good to guard the weak, to strike at evil wherever it arises, and to stand vigilant against the darkness. From a young age, a protector aasimar receives advice and directives that urge to stand against evil.</p>
       <p>     
         <span class="feature">Ability Score Increase.</span>Your Wisdom score increases by 1.<br />
         <span class="feature">Radiant Soul.</span>Starting at 3rd level, you can use your action to unleash the divine energy within yourself, causing your eyes to glimmer and two luminous, incorporeal wings to sprout from your back. Your transformation lasts for 1 minute or until you end it as a bonus action. During it, you have a flying speed of 30 feet, and once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra radiant damage equals your level. Once you use this trait, you can't use it again until you finish a long rest.<br />
@@ -140,7 +140,7 @@
   <element name="Scourge Aasimar" type="Sub Race" source="Volo’s Guide to Monsters" id="ID_WOTC_VGTM_SUB_RACE_Scourge_AASIMAR">
     <supports>Aasimar</supports>
     <description>
-      <p>Scourge aasimar are charged by the powers of good to guard the weak, to strike at evil wher,ever it arises, and to stand vigilant against the darkness. From a young age, a protector aasimar receives advice and directives that urge to stand against evil.</p>
+      <p>Scourge aasimar are imbued with a divine energy that blazes intensely within them. It feeds a powerful desire to destroy evil-a desire that is, at its best, unflinching and, at its worst, all-consuming. Many scourge aasimar wear masks to block out the world and focus on containing this power, unmasking themselves only in battle.</p>
       <p>     
         <span class="feature">Ability Score Increase.</span>Your Constitution score increases by 1.<br />
         <span class="feature">Radiant Consumption.</span>Starting at 3rd level, you can use your action to unleash the divine energy within yourself, causing a searing light to radiate from you, pour out of your eyes and mouth, and threaten to char you. Your transformation lasts for 1 minute or until you end it as a bonus action. During it, you shed bright light in a 10-foot radius and dim light for an additional 10 feet, and at the end of each of your turns, you and each creature within 10 feet of you take radiant damage equal to half your level (rounded up). In addition, once on each of your turns, you can deal extra radiant damage to one target when you deal damage to it with an attack or a spell. The extra radiant damage equals your level. Once you use this trait, you can't use it again until you finish a long rest.<br />


### PR DESCRIPTION
Identified and fixed several typos and also replaced a paragraph duplication under "Scourge Aasimar". The opening paragraph had been duplicated from "Protector Aasimar".