### PR TITLE
Typo fixes for Dominaria and Innistrad Human races

### DIFF
--- a/unearthed-arcana/planeshift/dominaria/race-keldon-human.xml
+++ b/unearthed-arcana/planeshift/dominaria/race-keldon-human.xml
@@ -4,7 +4,7 @@
 		<name>Human</name>
 		<description></description>
 		<author url="https://media.wizards.com/2018/downloads/magic/Plane_Shift_Dominaria.pdf">Wizards of the Coast</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="race-keldon-human.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/planeshift/dominaria/race-keldon-human.xml" />
 		</update>
 	</info>
@@ -19,7 +19,7 @@
       <p>
         <span class="feature">Ability Score Increase. </span> Your Strength score increases by 2, and your Constitution score increases by 1.<br />
         <span class="feature">Age. </span>Keldons reach adulthood in their late teens and live less than a century. <br />
-        <span class="feature">Alightment. </span>Keldons tend toward chaotic alignments, and many walk a fine line between good and evil.<br />
+        <span class="feature">Alignment. </span>Keldons tend toward chaotic alignments, and many walk a fine line between good and evil.<br />
         <span class="feature">Size. </span>Keldons are taller and heavier than the human norms of other cultures, standing almost universally above 6 feet tall and reaching heights above 7 feet. Your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
         <span class="feature">Languages. </span>You can speak, read, and write Common and Keldon.<br />

--- a/unearthed-arcana/planeshift/innistrad/race-human-innistrad.xml
+++ b/unearthed-arcana/planeshift/innistrad/race-human-innistrad.xml
@@ -4,7 +4,7 @@
 		<name>Human</name>
 		<description>Human Race Variants from Plane Shift: Innistrad</description>
 		<author url="https://media.wizards.com/2016/dnd/downloads/Plane_Shift_Innistrad.pdf">Wizards of the Coast</author>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="race-human-innistrad.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/planeshift/innistrad/race-human-innistrad.xml" />
 		</update>
 	</info>
@@ -18,7 +18,7 @@
       <p>
         <span class="feature">Ability Score Increase. </span>Your ability scores each increase by 1.<br />
         <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
-        <span class="feature">Alightment. </span>Humans tend toward no particular alignment.<br />
+        <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
         <span class="feature">Languages. </span>You can speak, read, and write Common and one extra language of your choice.<br />
@@ -37,7 +37,7 @@
       <p>
         <span class="feature">Ability Score Increase. </span> Your Dexterity and Wisdom scores each increase by 1.<br />
         <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
-        <span class="feature">Alightment. </span>Humans tend toward no particular alignment.<br />
+        <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 40 feet.<br />
         <span class="feature">Languages. </span>You can speak, read, and write Common and one extra language of your choice.<br />
@@ -94,7 +94,7 @@
       <p>
         <span class="feature">Ability Score Increase. </span> Your Intelligence and Charisma scores each increase by 1.<br />
         <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
-        <span class="feature">Alightment. </span>Humans tend toward no particular alignment.<br />
+        <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
         <span class="feature">Languages. </span>You can speak, read, and write Common and one extra language of your choice.<br />
@@ -121,7 +121,7 @@
       <p>
         <span class="feature">Ability Score Increase. </span> Your Strength and your Constitution score each increases by 1.<br />
         <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
-        <span class="feature">Alightment. </span>Humans tend toward no particular alignment.<br />
+        <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
         <span class="feature">Languages. </span>You can speak, read, and write Common and one extra language of your choice.<br />

--- a/unearthed-arcana/planeshift/innistrad/race-human-innistrad.xml
+++ b/unearthed-arcana/planeshift/innistrad/race-human-innistrad.xml
@@ -17,7 +17,7 @@
       <p>Whether safe behind the walls of the High City of Thraben or out in the moors with little more than shuttered windows, barred doors, and grim determination to stand against the horrors of the night, the humans of Gavony are the most well-rounded people of Innistrad.</p>
       <p>
         <span class="feature">Ability Score Increase. </span>Your ability scores each increase by 1.<br />
-        <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
+        <span class="feature">Age. </span>Humans reach adulthood in their late teens and live less than a century. <br />
         <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
@@ -36,7 +36,7 @@
       <p>For the Kessiger, life is work. Kessigers are farmers, millers, weavers, and stonemasons, living close to the land and working hard for every meal. This makes them self-reliant, pragmatic, and plainspoken. </p>
       <p>
         <span class="feature">Ability Score Increase. </span> Your Dexterity and Wisdom scores each increase by 1.<br />
-        <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
+        <span class="feature">Age. </span>Humans reach adulthood in their late teens and live less than a century. <br />
         <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 40 feet.<br />
@@ -93,7 +93,7 @@
       <p>Beneath an ever-present shroud of fog billowing in from the sea, the people of Nephalia maintain a semblance of normalcy, buying and selling goods from across Innistrad in their bustling markets, setting out to sea in tiny fishing boats, or tilling the soggy earth in waterlogged fields.</p>
       <p>
         <span class="feature">Ability Score Increase. </span> Your Intelligence and Charisma scores each increase by 1.<br />
-        <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
+        <span class="feature">Age. </span>Humans reach adulthood in their late teens and live less than a century. <br />
         <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />
@@ -120,7 +120,7 @@
       <p>Countless generations of hardship and proximity to the vampire strongholds—leading to lost children and neighbors—have taught Stensians to guard their hearts. They are proud and fervent in their beliefs but seem brusque or even cold to the people of other provinces.</p>
       <p>
         <span class="feature">Ability Score Increase. </span> Your Strength and your Constitution score each increases by 1.<br />
-        <span class="feature">Age. </span>Humans reach adulthood in their late teensand live less than a century. <br />
+        <span class="feature">Age. </span>Humans reach adulthood in their late teens and live less than a century. <br />
         <span class="feature">Alignment. </span>Humans tend toward no particular alignment.<br />
         <span class="feature">Size. </span>Humans vary widely in height and build, from barely 5 feet to well over 6 feet tall. Regardless of your position in that range, your size is Medium.<br />
         <span class="feature">Speed. </span>Your base walking speed is 30 feet.<br />


### PR DESCRIPTION
• Typo `alightment` fixed 
• Typo `teensand` fixed 