### PR TITLE
Change table heading for Battle Smith

### DIFF
--- a/unearthed-arcana/2019/20190514.xml
+++ b/unearthed-arcana/2019/20190514.xml
@@ -2,7 +2,7 @@
 <elements>
 	<info>
 		<name>Unearthed Arcana: The Artificer Returns</name>
-		<update version="0.0.1">
+		<update version="0.0.2">
 			<file name="20190514.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2019/20190514.xml" />
 		</update>
 	</info>

--- a/unearthed-arcana/2019/20190514.xml
+++ b/unearthed-arcana/2019/20190514.xml
@@ -261,7 +261,7 @@
 	<element name="Battle Smith Spells" type="Archetype Feature" source="Unearthed Arcana: The Artificer Returns" id="ID_WOTC_UA20190514_ARCHETYPE_FEATURE_ARTIFICER_BATTLE_SMITH_BATTLE_SMITH_SPELLS">
 		<description>
 			<p>Starting at 3rd level, you always have certain spells prepared after you reach particular levels in this class, as shown in the Battle Smith Spells table. These spells count as artificer spells for you, but they don’t count against the number of artificer spells you prepare.</p>
-			<h6>Archivist Spells</h6>
+			<h6>Battle Smith Spells</h6>
 			<table>
 				<thead><tr><td>Artificer Level</td><td>Spell</td></tr></thead>
 				<tr><td>3rd</td><td>heroism, searing smite</td></tr>


### PR DESCRIPTION
The table heading for the Battle Smith spells was incorrectly written as 'Archivist spells'. This PR changes that.