### PR TITLE
Fix duplicate of ID's

### DIFF
--- a/unearthed-arcana/2017/20170313.xml
+++ b/unearthed-arcana/2017/20170313.xml
@@ -1820,7 +1820,7 @@
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
-	<element name="Psychic Phantoms" type="Spell" source="Unearthed Arcana: The Mystic Class" id="ID_WOTC_UA20170313_SPELL_MYSTIC_NOMADIC_STEP">
+	<element name="Psychic Phantoms" type="Spell" source="Unearthed Arcana: The Mystic Class" id="ID_WOTC_UA20170313_SPELL_MYSTIC_PSYCHIC_PHANTOMS">
 		<supports>Psionic Disciplines</supports>
 		<requirements>ID_WOTC_UA20170313_CLASS_MYSTIC</requirements>
 		<description>

--- a/unearthed-arcana/2017/20170313.xml
+++ b/unearthed-arcana/2017/20170313.xml
@@ -4,7 +4,7 @@
 		<name>Mystic</name>
 		<description>Mystic from Unearthed Arcana.</description>
 		<author url="https://media.wizards.com/2017/dnd/downloads/UAMystic3.pdf">Wizards of the Coast</author>
-		<update version="0.0.3">
+		<update version="0.0.4">
 			<file name="20170313.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2017/20170313.xml" />
 		</update>
 	</info>


### PR DESCRIPTION
Nomadic Step and Psychic Phantoms shared the same ID (nomadic step) and thus the skill Nomadic Step doesn't show up.

I don't know if there is some specific format/source for the ID's but I just guessed based on the format of the others.