### PR TITLE
[UA] Protection Domain Spells fix

### DIFF
--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -202,12 +202,10 @@
   </element>
   <element name="Divine Domain" type="Class Feature" source="Player’s Handbook" id="ID_WOTC_PHB_CLASS_FEATURE_CLERIC_DIVINEDOMAIN">
     <description>
-      <p>In a pantheon, every deity has influence over different aspects of mortal life and civilization, called a deity’s domain. All the domains over which a deity has influence are called the deity’s portfolio. For example, the portfolio of the Greek god Apollo includes the domains of Knowledge, Life, and Light. As a cleric, you choose one aspect of your deity’s portfolio to emphasize, and you are granted powers related to that domain.</p>
-      <p class="indent">Your choice might correspond to a particular sect dedicated to your deity. Apollo, for example, could be worshiped in one region as Phoebus (“radiant”) Apollo, emphasizing his influence over the Light domain, and in a different place as Apollo Acesius (“healing”), emphasizing his association with the Life domain. Alternatively, your choice of domain could simply be a matter of personal preference, the aspect of the deity that appeals to you most.</p>
-      <p class="indent">Each domain’s description gives examples of deities who have influence over that domain. Gods are included from the worlds of the Forgotten Realms, Greyhawk, Dragonlance, and Eberron campaign settings, as well as from the Celtic, Greek, Norse, and Egyptian pantheons of antiquity.</p>
+      <p>Choose one domain related to your deity: Knowledge, Life, Light, Nature, Tempest, Trickery, or War. Each domain is detailed at the end of the class description, and each one provides examples of gods associated with it. Your choice grants you domain spells and other features when you choose it at 1st level. It also grants you additional ways to use Channel Divinity when you gain that feature at 2nd level, and additional benefits at 6th, 8th, and 17th levels.</p>
       <h5>DOMAIN SPELLS</h5>
-      <p>Each domain has a list of spells - its domain spells - that you gain at the c1eric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.</p>
-      <p class="indent">If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you.</p>
+      <p>Each domain has a list of spells—its domain spells—that you gain at the cleric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn’t count against the number of spells you can prepare each day.</p>
+      <p class="indent">If you have a domain spell that doesn’t appear on the cleric spell list, the spell is nonetheless a cleric spell for you.</p>
     </description>
     <sheet />
     <rules>

--- a/core/players-handbook/classes/class-cleric.xml
+++ b/core/players-handbook/classes/class-cleric.xml
@@ -4,7 +4,7 @@
     <name>Cleric</name>
     <description>The Cleric class from the Player’s Handbook.</description>
     <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-    <update version="0.3.5">
+    <update version="0.3.6">
       <file name="class-cleric.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/classes/class-cleric.xml" />
     </update>
   </info>
@@ -205,6 +205,9 @@
       <p>In a pantheon, every deity has influence over different aspects of mortal life and civilization, called a deity’s domain. All the domains over which a deity has influence are called the deity’s portfolio. For example, the portfolio of the Greek god Apollo includes the domains of Knowledge, Life, and Light. As a cleric, you choose one aspect of your deity’s portfolio to emphasize, and you are granted powers related to that domain.</p>
       <p class="indent">Your choice might correspond to a particular sect dedicated to your deity. Apollo, for example, could be worshiped in one region as Phoebus (“radiant”) Apollo, emphasizing his influence over the Light domain, and in a different place as Apollo Acesius (“healing”), emphasizing his association with the Life domain. Alternatively, your choice of domain could simply be a matter of personal preference, the aspect of the deity that appeals to you most.</p>
       <p class="indent">Each domain’s description gives examples of deities who have influence over that domain. Gods are included from the worlds of the Forgotten Realms, Greyhawk, Dragonlance, and Eberron campaign settings, as well as from the Celtic, Greek, Norse, and Egyptian pantheons of antiquity.</p>
+      <h5>DOMAIN SPELLS</h5>
+      <p>Each domain has a list of spells - its domain spells - that you gain at the c1eric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.</p>
+      <p class="indent">If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you.</p>
     </description>
     <sheet />
     <rules>

--- a/unearthed-arcana/2016/20161121.xml
+++ b/unearthed-arcana/2016/20161121.xml
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana: Cleric: Divine Domains</name>
 		<description>Clerics are blessed with new Divine Domain options in this week's Unearthed Arcana: the domains of the Forge, the Grave, and Protection. We invite you to read their descriptions, make characters with them, and see whether you like them.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana/cleric-divine-domains">Wizards of the Coast</author>
-		<update version="0.0.2">
+		<update version="0.0.3">
 			<file name="20161121.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2016/20161121.xml" />
 		</update>
 	</info>
@@ -64,16 +64,16 @@
         </description>
         <sheet display="false" />
         <rules>
-            <grant type="Spell" name="ID_PHB_SPELL_COMPELLED_DUEL" level="1" />
-            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" level="1" />
-            <grant type="Spell" name="ID_PHB_SPELL_AID" level="3" />
-            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_POISON" level="3" />
-            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" />
-            <grant type="Spell" name="ID_PHB_SPELL_SLOW" level="5" />
-            <grant type="Spell" name="ID_PHB_SPELL_GUARDIAN_OF_FAITH" level="7" />
-            <grant type="Spell" name="ID_PHB_SPELL_OTILUKES_RESILIENT_SPHERE" level="7" />
-            <grant type="Spell" name="ID_PHB_SPELL_ANTILIFE_SHELL" level="9" />
-            <grant type="Spell" name="ID_PHB_SPELL_WALL_OF_FORCE" level="9" />
+            <grant type="Spell" name="ID_PHB_SPELL_COMPELLED_DUEL" level="1" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_EVIL_AND_GOOD" level="1" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_AID" level="3" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_POISON" level="3" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_PROTECTION_FROM_ENERGY" level="5" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_SLOW" level="5" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_GUARDIAN_OF_FAITH" level="7" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_OTILUKES_RESILIENT_SPHERE" level="7" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_ANTILIFE_SHELL" level="9" spellcasting="Cleric" prepared="true" />
+            <grant type="Spell" name="ID_PHB_SPELL_WALL_OF_FORCE" level="9" spellcasting="Cleric" prepared="true" />
         </rules>
     </element> 
     <element name="Bonus Proficiency" type="Archetype Feature" source="Unearthed Arcana: Cleric: Divine Domains" id="ID_WOTC_UA20161121_ARCHETYPE_FEATURE_PROTECTION_DOMAIN_BONUS_PROFICIENCY">


### PR DESCRIPTION
[Subreddit post about the problem](https://www.reddit.com/r/aurorabuilder/comments/d4x2ko/cleric_of_protection_domain_doesnt_show_its_spells/)
• Protection Domain Spells now count as Cleric spells and always prepared.
• Added missing description into Cleric's Divine Domain feature, description that is referenced in every Domain Spells Archetype Feature.