### PR TITLE
Hill Dwarf - Dwarven Toughness not displayed

### DIFF
--- a/core/players-handbook/races/race-dwarf.xml
+++ b/core/players-handbook/races/race-dwarf.xml
@@ -162,7 +162,7 @@
     <description>
       <p>Your hit point maximum increases by 1, and it increases by 1 every time you gain a level.</p>
     </description>
-    <sheet display="false">
+    <sheet display="true">
       <description>Your hit point maximum increases by 1, and it increases by 1 every time you gain a level.</description>
     </sheet>
     <rules>


### PR DESCRIPTION
Hill Dwarf - Dwarven Toughness - it works but is not displayed in Character sheet. 
It was displayed before I downloaded core in "Additional content".