### PR TITLE
UA 20190815: Barbarian and Monk Fix

### DIFF
--- a/unearthed-arcana/2019/20190815.xml
+++ b/unearthed-arcana/2019/20190815.xml
@@ -4,7 +4,7 @@
         <name>Unearthed Arcana: Barbarian and Monk</name>
         <description>The barbarian receives a new Primal Path feature: Path of the Wild Soul. Meanwhile the monk gains a new Monastic Tradition feature: the Way of the Astral Self.</description>
         <author url="https://dnd.wizards.com/articles/unearthed-arcana/barbarian-and-monk">Wizards of the Coast</author>
-        <update version="0.0.1">
+        <update version="0.0.2">
             <file name="20190815.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2019/20190815.xml" />
         </update>
     </info>
@@ -82,7 +82,7 @@
             </ul>
         </description>
         <sheet>
-            <description>When you have both your Astral Arms and Astral Viage summoned you gain additional benefits. When you take acid, cold, fire, lightning or force damage you can use your reaction to reduce it by 1d10 + {{astral:energy deflect}}. Once per turn when you hit a target with your astral arms you can deal {{martial arts:dice}} extra damage. When you speak through your Visage you can either direct your words towards a creature within 30 feet or allow all creatures within 600ft to hear you.</description>
+            <description>When you have both your Astral Arms and Astral Visage summoned you gain additional benefits. When you take acid, cold, fire, lightning or force damage you can use your reaction to reduce it by 1d10 + {{astral:energy deflect}}. Once per turn when you hit a target with your astral arms you can deal {{martial arts:dice}} extra damage. When you speak through your Visage you can either direct your words towards a creature within 30 feet or allow all creatures within 600ft to hear you.</description>
         </sheet>
         <rules>
             <stat name="astral:energy deflect" value="level:monk" />
@@ -160,7 +160,7 @@
         <rules>
             <stat name="wild surge:dc" value="8" />
             <stat name="wild surge:dc" value="proficiency" />
-            <stat name="wild surge:dc" value="constitution:modifer" />
+            <stat name="wild surge:dc" value="constitution:modifier" />
         </rules>
     </element>
     <element name="Magic Reserve" type="Archetype Feature" source="Unearthed Arcana: Barbarian and Monk" id="ID_WOTC_UA_WILD_SOUL_ARCHETYPE_FEATURE_MAGIC_RESERVE">
@@ -170,8 +170,8 @@
             <p class="indent">When you reach 14th level in this class, you increase the die to a d6.</p>
         </description>
         <sheet action="Action">
-            <description>Touch a creature and roll a d4. The creature regains an expended spell slot equal to the level rolled. If the crature cannot regain the spell slot they gain temporary HP equal to 5 times the number rolled. You take force damage equal to the number rolled.</description>
-            <description level="14">Touch a creature and roll a d6. The creature regains an expended spell slot equal to the level rolled. If the crature cannot regain the spell slot they gain temporary HP equal to 5 times the number rolled. You take force damage equal to the number rolled.</description>
+            <description>Touch a creature and roll a d4. The creature regains an expended spell slot equal to the level rolled. If the creature cannot regain the spell slot they gain temporary HP equal to 5 times the number rolled. You take force damage equal to the number rolled.</description>
+            <description level="14">Touch a creature and roll a d6. The creature regains an expended spell slot equal to the level rolled. If the creature cannot regain the spell slot they gain temporary HP equal to 5 times the number rolled. You take force damage equal to the number rolled.</description>
         </sheet>
     </element>
     <element name="Arcane Rebuke" type="Archetype Feature" source="Unearthed Arcana: Barbarian and Monk" id="ID_WOTC_UA_WILD_SOUL_ARCHETYPE_FEATURE_ARCANE_REBUKE">


### PR DESCRIPTION
requested on Discord by user _**Malazim**#9841_
• changed `value="constitution:modifer"`  in Wild Surge to proper `value="constitution:modifier"`
• typo "Viage" fixed
• typo "crature" fixed