### PR TITLE
Fix armor weight values for Padded, Leather, Studded Leather, and Hide Armor

### DIFF
--- a/core/players-handbook/items/items-armor.xml
+++ b/core/players-handbook/items/items-armor.xml
@@ -4,7 +4,7 @@
 		<name>Armor</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.0.4">
+		<update version="0.0.5">
 			<file name="items-armor.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/items/items-armor.xml" />
 		</update>
 	</info>

--- a/core/players-handbook/items/items-armor.xml
+++ b/core/players-handbook/items/items-armor.xml
@@ -17,7 +17,7 @@
 		</description>
 		<setters>
 			<set name="cost" currency="gp">5</set>
-			<set name="weight" lb="1">8 lb.</set>
+			<set name="weight" lb="8">8 lb.</set>
 			<set name="slot">body</set>
 			<set name="armor">Light</set>
 			<set name="armorClass">11 + Dex modifier</set>
@@ -36,7 +36,7 @@
 		</description>
 		<setters>
 			<set name="cost" currency="gp">10</set>
-			<set name="weight" lb="1">10 lb.</set>
+			<set name="weight" lb="10">10 lb.</set>
 			<set name="slot">body</set>
 			<set name="armor">Light</set>
 			<set name="armorClass">11 + Dex modifier</set>
@@ -53,7 +53,7 @@
 		</description>
 		<setters>
 			<set name="cost" currency="gp">45</set>
-			<set name="weight" lb="1">13 lb.</set>
+			<set name="weight" lb="13">13 lb.</set>
 			<set name="slot">body</set>
 			<set name="armor">Light</set>
 			<set name="armorClass">12 + Dex modifier</set>
@@ -72,7 +72,7 @@
 		</description>
 		<setters>
 			<set name="cost" currency="gp">10</set>
-			<set name="weight" lb="1">12 lb.</set>
+			<set name="weight" lb="12">12 lb.</set>
 			<set name="slot">body</set>
 			<set name="armor">Medium</set>
 			<set name="armorClass">12 + Dex modifier (max 2)</set>


### PR DESCRIPTION
The written weight did not line up with the weight attribute. Now it does.