### PR TITLE
Odyssey of the Dragonlords initial

### DIFF
--- a/third-party.index
+++ b/third-party.index
@@ -13,6 +13,7 @@
 		<file name="kobold-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/kobold-press.index" />
 		<file name="genuine-fantasy-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/genuine-fantasy-press.index" />
 		<file name="mage-hand-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/mage-hand-press.index" />
+    <file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />
 		
 		<obsolete name="sources.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/sources.xml" />
 		<obsolete name="dnd-wiki.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki.index" />

--- a/third-party.index
+++ b/third-party.index
@@ -3,7 +3,7 @@
 	<info>
 		<name>Third Party</name>
 		<description>The content from various third party sources.</description>
-		<update version="0.2.1">
+		<update version="0.2.2">
 			<file name="third-party.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party.index" />
 		</update>
 	</info>
@@ -13,8 +13,7 @@
 		<file name="kobold-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/kobold-press.index" />
 		<file name="genuine-fantasy-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/genuine-fantasy-press.index" />
 		<file name="mage-hand-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/mage-hand-press.index" />
-    <file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />
-		
+    	<file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />		
 		<obsolete name="sources.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/sources.xml" />
 		<obsolete name="dnd-wiki.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki.index" />
 	</files>

--- a/third-party.index
+++ b/third-party.index
@@ -13,7 +13,7 @@
 		<file name="kobold-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/kobold-press.index" />
 		<file name="genuine-fantasy-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/genuine-fantasy-press.index" />
 		<file name="mage-hand-press.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/mage-hand-press.index" />
-    	<file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />		
+		<file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />
 		<obsolete name="sources.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/sources.xml" />
 		<obsolete name="dnd-wiki.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dnd-wiki.index" />
 	</files>

--- a/third-party/arcanum-worlds.index
+++ b/third-party/arcanum-worlds.index
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<index>
+	<info>
+		<name>Arcanum Worlds</name>
+		<update version="0.0.1">
+			<file name="arcanum-worlds.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds.index" />
+		</update>
+	</info>
+	<files>
+		<file name="odyssey-of-the-dragonlords.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index" />
+	</files>
+</index>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<index>
+	<info>
+		<name>Odyssey of the Dragonlords</name>
+		<description>Odyssey of the Dragonlords is an epic adventure book for the 5th Edition of the world's greatest roleplaying game.</description>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1" revised="">
+			<file name="odyssey-of-the-dragonlords.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index" />
+		</update>
+	</info>
+	<files>
+		<file name="source.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml" />
+		<file name="aw-ootd-spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
+		<file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml" />
+		<file name="race-thyleancentaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml" />
+		<file name="race-thyleanmedusa.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml" />
+		<file name="race-thyleanminotaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml" />
+		<file name="race-thyleannymph.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml" />
+		<file name="race-thyleansatyr.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml" />
+		<file name="race-thyleansiren.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml" />
+		<file name="subclass-barbarian-herculean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml" />
+		<file name="subclass-bard-epicpoetry.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml" />
+		<file name="subclass-cleric-prophecy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml" />
+		<file name="subclass-druid-sacrifice.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml" />
+		<file name="subclass-fighter-hoplite.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml" />
+		<file name="subclass-monk-shield.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml" />
+		<file name="subclass-paladin-dragonlord.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml" />
+		<file name="subclass-ranger-amazonian.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml" />
+		<file name="subclass-rogue-odyssean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml" />
+		<file name="subclass-sorcerer-demigod.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml" />
+		<file name="subclass-warlock-fates.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml" />
+		<file name="subclass-wizard-academy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml" />
+	</files>
+</index>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
@@ -10,8 +10,6 @@
 	</info>
 	<files>
 		<file name="source.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml" />
-		<file name="aw-ootd-spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
-		<file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml" />
 		<file name="race-thyleancentaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml" />
 		<file name="race-thyleanmedusa.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml" />
 		<file name="race-thyleanminotaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml" />
@@ -30,5 +28,7 @@
 		<file name="subclass-sorcerer-demigod.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml" />
 		<file name="subclass-warlock-fates.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml" />
 		<file name="subclass-wizard-academy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml" />
+		<file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml" />
+		<file name="items.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml" />
 	</files>
 </index>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index
@@ -2,8 +2,6 @@
 <index>
 	<info>
 		<name>Odyssey of the Dragonlords</name>
-		<description>Odyssey of the Dragonlords is an epic adventure book for the 5th Edition of the world's greatest roleplaying game.</description>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1" revised="">
 			<file name="odyssey-of-the-dragonlords.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords.index" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
@@ -3,10 +3,11 @@
     <info>
 		  <author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		  <update version="0.0.1">
-			  <file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
+			  <file name="aw-ootd-spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
 		  </update>
 	</info>
-    <element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
+
+  <element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
     <supports>Druid, Ranger, Sorcerer</supports>
     <description>
       <p>This spell transforms a creature you can see within range into a new beast form. An unwilling creature must make a Wisdom saving throw to avoid the effect. A shapechanger automatically succeeds on this saving throw.</p>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-		  <author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		  <update version="0.0.1">
 			  <file name="aw-ootd-spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
 		  </update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+		  <author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		  <update version="0.0.1">
+			  <file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
+		  </update>
+	</info>
+    <element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
+    <supports>Druid, Ranger, Sorcerer</supports>
+    <description>
+      <p>This spell transforms a creature you can see within range into a new beast form. An unwilling creature must make a Wisdom saving throw to avoid the effect. A shapechanger automatically succeeds on this saving throw.</p>
+      <p class="indent">The transformation lasts for the duration, or until the target drops to 0 hit points or dies. The new form can be any beast of CR 1 or less that does not have a fly speed. While in this new form, the target is charmed by you and views you as a trusted ally. The target can understand simple commands such as “attack” or “stay.” The charm affects creatures that are immune to charm in their normal form. The charm ends immediately when the target reverts to its normal form.</p>
+      <p class="indent">The target’s game statistics, including mental ability scores, are replaced by the statistics of the chosen beast. It retains its alignment and personality. The creature is limited in the actions it can perform by the nature of its new form, and it can’t speak, cast spells, or take any other action that requires hands or speech. The creature's gear melds into its new form. The creature can’t activate, use, wield, or otherwise benefit from any of its equipment.</p>
+      <p class="indent">The target assumes the hit points of its new form. When it reverts to its normal form, the creature returns to the number of hit points it had before it transformed. If it reverts as a result of dropping to 0 hit points, any excess damage carries over to its normal form.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">3</set>
+      <set name="school">Transmutation</set>
+      <set name="time">1 action</set>
+      <set name="duration">Concentration, up to 10 minutes</set>
+      <set name="range">60 feet</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">true</set>
+      <set name="hasMaterialComponent">false</set>
+      <set name="materialComponent" />
+      <set name="isConcentration">true</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Bond of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_BOND_OF_THE_DRAGONLORDS">
+    <supports>Paladin</supports>
+    <description>
+      <p>You permanently bond with a newly-hatched metallic dragon. This requires you to locate an unhatched dragon egg and spend 1d4 days nurturing the egg so that it hatches. The hatchling may be any of the following types of dragon wyrmling: brass, bronze, copper, or silver.</p>
+      <p class="indent">You can confer the bond to another recipient who you are touching when you cast the spell. A dragon that has been bonded can never be bonded with another target. Likewise, this spell cannot be used to bond more than one dragon to any individual.</p>
+      <p class="indent">Wyrmlings cannot be used as mounts until they grow into young dragons. A dragon cannot use legendary actions while it is being used as a mount.</p>
+      <p class="indent"><b><i>Controlling the Dragon.</i></b> Your dragon moves and acts on your initiative. You can decide how the dragon moves and attacks. While your dragon is fighting alongside you, it loses its multiattack feature. If your dragon has a breath weapon, it can be used once, and it recharges after you and the dragon complete a long rest.</p>
+      <p class="indent">If your bonded dragon dies, you will also die within 24 hours unless the dragon is returned to life. You cannot be raised from the dead unless your bonded dragon is alive. The same is true for your dragon.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">2</set>
+      <set name="school">Enchantment</set>
+      <set name="time">1 minute</set>
+      <set name="duration">Special</set>
+      <set name="range">Touch</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">false</set>
+      <set name="hasMaterialComponent">true</set>
+      <set name="materialComponent">magical armor, shield, weapon, ring, rod, staff, or wand worth at least 5,000 gp, which the spell consumes, and an unhatched dragon egg</set>
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Dirge of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_DIRGE_OF_THE_DRAGONLORDS">
+    <supports>Bard, Cleric, Paladin</supports>
+    <description>
+      <p>You return a dead dragon that has been bonded to a Dragonlord back to life. The dragon returns to life with 1 hit point. All of the dragon's mortal wounds are closed, and any missing body parts are restored.</p>
+      <p class="indent">This spell also neutralizes any poisons and cures nonmagical diseases that affected the dragon at the time it died. This spell doesn’t, however, remove magical diseases, curses, or similar effects; if these aren’t first removed prior to casting the spell, they take effect when the dragon returns to life.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">3</set>
+      <set name="school">Necromancy</set>
+      <set name="time">1 hour</set>
+      <set name="duration">Instantaneous</set>
+      <set name="range">Touch</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">false</set>
+      <set name="hasMaterialComponent">true</set>
+      <set name="materialComponent">an offering of gems and coins worth at least 1,000 gp, which the spell consumes</set>
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Fatebinding" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_FATEBINDING">
+    <supports>Bard, Cleric, Warlock, Wizard</supports>
+    <description>
+      <p>Choose two creatures that you can see. Both creatures must make Charisma saving throws, and they do so with advantage if they are hostile to you. If a creature is charmed by you, it has disadvantage on this saving throw. If both creatures fail their saving throws, then their fates are now bound together.</p>
+      <ul>
+        <li>Whenever one of the creatures takes damage, the other creature takes an identical amount of damage, unless both creatures took damage from the same single source, such as a <i>fireball</i> spell.</li>
+        <li>Whenever one of the creatures regains hit points, the other creature regains an identical number of hit points, unless both creatures regained hit points from the same single source, such as <i>mass cure wounds</i>.</li>
+      </ul>
+      <p>The two target creatures remain fate-bound for the duration of the spell, even if both targets are on different planes of existence.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">3</set>
+      <set name="school">Necromancy</set>
+      <set name="time">1 action</set>
+      <set name="duration">1 hour</set>
+      <set name="range">30 feet</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">false</set>
+      <set name="hasMaterialComponent">false</set>
+      <set name="materialComponent" />
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Seeds of Death" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SEEDS_OF_DEATH">
+    <supports>Druid, Sorcerer, Warlock, Wizard</supports>
+    <description>
+      <p>You throw three minotaur teeth on to the ground in front of you. At the start of your next turn, three <b>minotaur skeletons</b> erupt from the ground, fully formed. You can use a bonus action to shout commands at the minotaur skeletons if they are within 100 ft. of you. Your commands must be general orders, such as "attack that enemy" or "guard this room." Once given an order, the minotaur skeletons will continue to follow it until the task is complete or until you issue another command. If the minotaur skeletons are given no commands, they will attack the nearest creature. When the spell ends, the minotaur skeletons dissolve into bone dust.</p>
+      <p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th level or higher, you animate an extra minotaur skeleton for each slot level above 6th.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">6</set>
+      <set name="school">Necromancy</set>
+      <set name="time">1 action</set>
+      <set name="duration">Concentration, up to 10 minutes</set>
+      <set name="range">30 feet</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">true</set>
+      <set name="hasMaterialComponent">true</set>
+      <set name="materialComponent">three or more minotaur teeth and alchemical fertilizer worth 100 gp</set>
+      <set name="isConcentration">true</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Sleeping Draught" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SLEEPING_DRAUGHT">
+    <supports>Bard, Warlock, Wizard</supports>
+    <description>
+      <p>You open a draught and a purple mist flows from you to a target creature. Roll 9d8; if the target creature has fewer current hit points than the total, then it falls unconscious. The target remains unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. If the target creature has more hit points than the rolled total, then it becomes drowsy and its speed is halved, it can’t take reactions, and it can’t make more than one melee or ranged attack during its turn. The target remains drowsy until it takes damage or until the spell ends.</p>
+      <p class="indent">Undead and creatures that are immune to being charmed aren’t affected by this spell.</p>
+      <p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, roll an additional 3d8 for each slot level above the 2nd.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">2</set>
+      <set name="school">Enchantment</set>
+      <set name="time">1 action</set>
+      <set name="duration">1 minute</set>
+      <set name="range">20 feet</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">true</set>
+      <set name="hasMaterialComponent">true</set>
+      <set name="materialComponent">a draught of liquid</set>
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Sword of Fate" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SWORD_OF_FATE">
+    <supports>Bard, Cleric, Warlock, Wizard</supports>
+    <description>
+      <p>Choose a creature that you can see. You create an illusionary sword that hangs above that creature's head. Everyone with line of sight can see the sword except for the affected creature. When you cast the spell you must shout out one of the following conditions:</p>
+      <ul>
+        <li><i>You cannot harm us.</i> The target creature breaks this condition if they target the spell caster or a companion with an attack or a spell that causes damage.</li>
+        <li><i>You cannot use magic.</i> The target creature breaks this condition if they cast a spell.</li>
+        <li><i>You cannot leave this area.</i> The target creature breaks this condition if it moves more than 30 feet from the spot it was standing when the spell was cast.</li>
+      </ul>
+      <p class="indent">If the target creature breaks the condition, it takes 10d8 slashing damage as the blade becomes real and slices downward. If the target is reduced to 0 hit points, then one of its heads is removed. If the creature has no remaining heads, then it is instantly killed.</p>
+      <p class="indent">The sword of fate can be dispelled. In addition, remove curse will end the spell on the target.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">5</set>
+      <set name="school">Illusion</set>
+      <set name="time">1 action</set>
+      <set name="duration">1 hour</set>
+      <set name="range">60 feet</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">false</set>
+      <set name="hasMaterialComponent">false</set>
+      <set name="materialComponent" />
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+
+  <element name="Theogenesis" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_THEOGENESIS">
+    <supports>Cleric, Sorcerer, Wizard</supports>
+    <description>
+      <p><i>Theogenesis</i> is a powerful spell that is used to place a divine spark into a mortal creature, unlocking the potential to ascend to godhood. The artifacts are not consumed when the spell is cast, but the offerings are.</p>
+      <p class="indent">Choose a single target (non-divine) creature for the spell. You must remain in contact with the target for the duration of the casting. If contact is broken, both you and the target take 20d6 radiant damage, and both the spell and the offering are wasted. If the spell is successfully cast, then one of the greater gods must decide whether or not to grant the divine spark. The creature's relationship with the god determines its chance of success, and the base chance is 0%. Each of the bonuses below are cumulative:</p>
+      <ul>
+        <li>The target shares at least one alignment axis with the greater god: +20%</li>
+        <li>The target has the exact same alignment as the greater god: +20%</li>
+        <li>The target has faithfully worshipped a god in the same pantheon for at least a year: +20%</li>
+        <li>The target has faithfully worshipped the greater god for at least a year: +30%</li>
+      </ul>
+      <p class="indent">Failure means that the greater god decides not to grant the divine spark. That greater god can’t be chosen again if the spell is cast on the same target. Success means that the target has been permanently granted a divine spark. It can only be removed with a wish spell.</p>
+    </description>
+    <setters>
+      <set name="keywords"></set>
+      <set name="level">9</set>
+      <set name="school">Conjuration</set>
+      <set name="time">1 hour</set>
+      <set name="duration">Special</set>
+      <set name="range">Touch</set>
+      <set name="hasVerbalComponent">true</set>
+      <set name="hasSomaticComponent">true</set>
+      <set name="hasMaterialComponent">true</set>
+      <set name="materialComponent">offerings worth at least 10,000 gp, which are consumed, and all three Divine Artifacts: the Caduceus, the Ambrosia, and the Promethean fire</set>
+      <set name="isConcentration">false</set>
+      <set name="isRitual">false</set>
+    </setters>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml" />
+		</update>
+	</info>
+
+	<!-- martial -->
+	<element name="Chakram" type="Weapon" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_PHB_WEAPON_CHAKRAM">
+		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
+		<description>
+			<p></p>
+            <div element="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM" />
+		</description>
+		<setters>
+			<set name="category">Weapons</set>
+			<set name="cost" currency="gp">10</set>
+			<set name="weight" lb="2">2 lb.</set>
+			<set name="slot">onehand</set>
+            <set name="range">60/120</set>
+			<set name="damage" type="slashing">1d6</set>
+			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_CHAKRAM</set>
+		</setters>
+	</element>
+
+    <!-- properties -->
+    <element name="Special (Chakram)" type="Weapon Property" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM">
+		<description>
+			<p>The chakram returns to you when thrown, unless you fumble the attack by rolling a natural 1.</p>
+		</description>
+	</element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml" />
 		</update>
 	</info>
 
 	<!-- martial -->
-	<element name="Chakram" type="Weapon" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_PHB_WEAPON_CHAKRAM">
+	<element name="Chakram" type="Weapon" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_CHAKRAM">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 		<description>
 			<p></p>
@@ -30,5 +29,10 @@
 		<description>
 			<p>The chakram returns to you when thrown, unless you fumble the attack by rolling a natural 1.</p>
 		</description>
+	</element>
+
+	<!-- proficiencies -->
+	<element name="Weapon Proficiency (Chakram)" type="Proficiency" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM">
+		<supports>Weapon, Martial, Melee, Thrown, ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 	</element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml
@@ -5,30 +5,30 @@
 			<file name="items.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml" />
 		</update>
 	</info>
-	
+
 	<!-- todo: treasures apendix G p444 -->
 
 	<element name="Chakram" type="Weapon" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_CHAKRAM">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 		<description>
 			<p>This bladed circular disc is an unusual thrown weapon. It glides through the air, slicing through anything in its path. Warriors who specialize with the chakram can learn to throw it in such a way that it returns to them after cutting the enemy.</p>
-            <div element="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM" />
+			<div element="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM" />
 		</description>
 		<setters>
 			<set name="category">Weapons</set>
 			<set name="cost" currency="gp">10</set>
 			<set name="weight" lb="2">2 lb.</set>
 			<set name="slot">onehand</set>
-            <set name="range">60/120</set>
+			<set name="range">60/120</set>
 			<set name="damage" type="slashing">1d6</set>
 			<set name="proficiency">ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM</set>
 		</setters>
-	</element>	
-    <element name="Special (Chakram)" type="Weapon Property" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM">
+	</element>
+	<element name="Special (Chakram)" type="Weapon Property" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM">
 		<description>
 			<p>The chakram returns to you when thrown, unless you fumble the attack by rolling a natural 1.</p>
 		</description>
-	</element>	
+	</element>
 	<element name="Weapon Proficiency (Chakram)" type="Proficiency" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM">
 		<supports>Weapon, Martial, Melee, Thrown, ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 	</element>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml
@@ -2,15 +2,16 @@
 <elements>
 	<info>
 		<update version="0.0.1">
-			<file name="aw-ootd-weapons.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-weapons.xml" />
+			<file name="items.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/items.xml" />
 		</update>
 	</info>
+	
+	<!-- todo: treasures apendix G p444 -->
 
-	<!-- martial -->
 	<element name="Chakram" type="Weapon" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_CHAKRAM">
 		<supports>ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 		<description>
-			<p></p>
+			<p>This bladed circular disc is an unusual thrown weapon. It glides through the air, slicing through anything in its path. Warriors who specialize with the chakram can learn to throw it in such a way that it returns to them after cutting the enemy.</p>
             <div element="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM" />
 		</description>
 		<setters>
@@ -20,19 +21,20 @@
 			<set name="slot">onehand</set>
             <set name="range">60/120</set>
 			<set name="damage" type="slashing">1d6</set>
-			<set name="proficiency">ID_PROFICIENCY_WEAPON_PROFICIENCY_CHAKRAM</set>
+			<set name="proficiency">ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM</set>
 		</setters>
-	</element>
-
-    <!-- properties -->
+	</element>	
     <element name="Special (Chakram)" type="Weapon Property" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROPERTY_SPECIAL_CHAKRAM">
 		<description>
 			<p>The chakram returns to you when thrown, unless you fumble the attack by rolling a natural 1.</p>
 		</description>
-	</element>
-
-	<!-- proficiencies -->
+	</element>	
 	<element name="Weapon Proficiency (Chakram)" type="Proficiency" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM">
 		<supports>Weapon, Martial, Melee, Thrown, ID_INTERNAL_WEAPON_CATEGORY_MARTIAL_MELEE, ID_INTERNAL_DAMAGE_TYPE_SLASHING, ID_INTERNAL_WEAPON_PROPERTY_LIGHT, ID_INTERNAL_WEAPON_PROPERTY_THROWN, ID_INTERNAL_WEAPON_PROPERTY_FINESSE, ID_INTERNAL_WEAPON_PROPERTY_SPECIAL_CHAKRAM</supports>
 	</element>
+	<append id="ID_PROFICIENCY_WEAPON_PROFICIENCY_MARTIAL_MELEE_WEAPONS">
+		<rules>
+			<grant type="Proficiency" id="ID_AW_OOTD_WEAPON_PROFICIENCY_CHAKRAM" />
+		</rules>
+	</append>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Centaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_CENTAUR">
-    <supports />
     <description>
       <p class="flavor">A noble race that roams the great plains of the world, centaurs are both feared and respected by other intelligent creatures. Centaur legends claim that they are the offspring of a powerful god of war that came down to the mortal plane in the form of a stallion. They are proud of this divine heritage and demand that the proper respect be shown to them.</p>
 
@@ -68,7 +67,6 @@
   </element>
 
   <element name="Charge" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_CHARGE">
-    <supports />
     <description>
       <p>If you move 30 feet straight toward a target and then hit them with a melee attack on the same turn, the target takes an extra 1d6 damage from the first attack.</p>
     </description>
@@ -78,7 +76,6 @@
   </element>
 
   <element name="Mountable" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_MOUNTABLE">
-    <supports />
     <description>
       <p>As a bonus action on your turn, you may allow a single willing ally within 5 feet of you to hitch a brief ride on your back. They are carried on your back until the end of your turn, at which point they must disembark within 5 feet of you. While being carried, your rider is not considered to be mounted and they are not vulnerable to attacks of opportunity. Your rider must be a bipedal creature of your size or smaller.</p>
     </description>
@@ -88,7 +85,6 @@
   </element>
 
   <element name="Quadrapedal Stride" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_QUADRAPEDAL_STRIDE">
-    <supports />
     <description>
       <p>Climbing or maneuvering in tight spaces is considered difficult terrain for you.</p>
     </description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
@@ -8,28 +8,22 @@
   <element name="Thylean Centaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_CENTAUR">
     <description>
       <p class="flavor">A noble race that roams the great plains of the world, centaurs are both feared and respected by other intelligent creatures. Centaur legends claim that they are the offspring of a powerful god of war that came down to the mortal plane in the form of a stallion. They are proud of this divine heritage and demand that the proper respect be shown to them.</p>
-
       <h4>EQUINE NOMADS</h4>
       <p>Centaurs possess a humanoid torso with a horse’s lower body. They are as varied in coloration and physical build as humans and horses. Their horse body can be chestnut brown, black as a nightmare, pure white as a unicorn, grey, and other colors between. They can be a single color, spotted, have white “socks,” or have hooves of different coloration. Their human bodies can be of any skin color from dark skinned to pale. Their human hair can be black, brown, blonde, or red—but it most often complements that of their horse body.</p>
-
       <h4>PROUD AND HAUGHTY</h4>
       <p>Centaurs are a proud people. They view themselves as superior to all other races and demand respect and adulation. They can be vain about their appearance and are careful to be dignified and aloof in the presence of others. However, most centaurs are also fond of drink and once inebriated they can become loud, boorish, and dangerous.</p>
-
       <h4>CENTAUR TRIBES</h4>
       <p>Centaurs are a tribal people. Centaurs are fiercely loyal to members of their tribe and will never leave one of their own behind. When they mate, they mate for life. If they join an adventuring group, they will often consider that group to be their current tribe and will be intensely loyal to their fellow heroes.</p>
       <p class="indent">They normally roam huge expanses of steppe land that they consider their domain. They don’t build settlements in these lands, but they are protective of them. While centaurs can be herbivores, they prefer meat and enjoy hunting, but they will resort to gathering fruit, nuts, and other plants if an area has been overhunted. Travelers who are respectful of the plants and animals in tribal territory are left alone, but those who disrespect nature or try to build permanent settlements of any kind will become a target of the tribe’s wrath.</p>
-
       <h4>CENTAURS IN THYLEA</h4>
       <p>Centaurs are distrustful of the civilized races. In the First War that raged five centuries ago, thousands of centaurs were killed by the invading Dragonlords, and the centaurs have never forgotten or forgiven. The distrust is mutual, especially as centaur tribes are now flocking to the banner of Sydon and raiding outlying farms. Centaurs that enter a Thylean town or city will find that they are tolerated but kept under constant watch.</p>
       <p class="indent">The centaurs tend to worship the mother goddess, but they will sometimes offer prayers to one of the titans, Sydon or Lutheria. They never worship the Five.</p>
-
       <h4>CENTAUR NAMES</h4>
       <p>Centaurs have names that are specific to their race. These names can often be difficult for members of other races to pronounce, so they can adopt nicknames when traveling with a band of non-centaurs.</p>
       <p>
         <span class="feature">Male Names:</span>Agrius (Agri), Amycus (Amy), Asbolus (Az), Bienor, Chiron, Cyllarus (Cyl), Dictys, Eurytus (Tus), Elatus, Eurytion (Yuri), Hylaeus (Hyla), Nessus, Perimedes (Peri), Pholus, Rhoetus (Rote), and Thaumas (Tom).<br/>
         <span class="feature">Female Names:</span>Agaria, Biano, Cylla, Diena, Eura, Hylonome (Hylo), Heranae (Hera), Nessicana (Nessie), Nara, Ponadata (Pona), Rhaelatisis (Rala), Rhaena (Rain), and Seranu (Sara).
       </p>
-
       <h4>CENTAUR TRAITS</h4>
       <p>Centaurs have the following racial traits.</p>
       <p>
@@ -44,7 +38,7 @@
         <span class="feature">Quadrapedal Stride.</span>Climbing or maneuvering in tight spaces is considered difficult terrain for you.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Centaur" display="false" />
     <setters>
       <set name="names" type="male">Agrius (Agri), Amycus (Amy), Asbolus (Az), Bienor, Chiron, Cyllarus (Cyl), Dictys, Eurytus (Tus), Elatus, Eurytion (Yuri), Hylaeus (Hyla), Nessus, Perimedes (Peri), Pholus, Rhoetus (Rote), and Thaumas (Tom)</set>
       <set name="names" type="female">Agaria, Biano, Cylla, Diena, Eura, Hylonome (Hylo), Heranae (Hera), Nessicana (Nessie), Nara, Ponadata (Pona), Rhaelatisis (Rala), Rhaena (Rain), and Seranu (Sara)</set>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleancentaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml" />
+		</update>
+	</info>
+  <element name="Thylean Centaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_CENTAUR">
+    <supports />
+    <description>
+      <p class="flavor">A noble race that roams the great plains of the world, centaurs are both feared and respected by other intelligent creatures. Centaur legends claim that they are the offspring of a powerful god of war that came down to the mortal plane in the form of a stallion. They are proud of this divine heritage and demand that the proper respect be shown to them.</p>
+
+      <h4>EQUINE NOMADS</h4>
+      <p>Centaurs possess a humanoid torso with a horse’s lower body. They are as varied in coloration and physical build as humans and horses. Their horse body can be chestnut brown, black as a nightmare, pure white as a unicorn, grey, and other colors between. They can be a single color, spotted, have white “socks,” or have hooves of different coloration. Their human bodies can be of any skin color from dark skinned to pale. Their human hair can be black, brown, blonde, or red—but it most often complements that of their horse body.</p>
+
+      <h4>PROUD AND HAUGHTY</h4>
+      <p>Centaurs are a proud people. They view themselves as superior to all other races and demand respect and adulation. They can be vain about their appearance and are careful to be dignified and aloof in the presence of others. However, most centaurs are also fond of drink and once inebriated they can become loud, boorish, and dangerous.</p>
+
+      <h4>CENTAUR TRIBES</h4>
+      <p>Centaurs are a tribal people. Centaurs are fiercely loyal to members of their tribe and will never leave one of their own behind. When they mate, they mate for life. If they join an adventuring group, they will often consider that group to be their current tribe and will be intensely loyal to their fellow heroes.</p>
+      <p class="indent">They normally roam huge expanses of steppe land that they consider their domain. They don’t build settlements in these lands, but they are protective of them. While centaurs can be herbivores, they prefer meat and enjoy hunting, but they will resort to gathering fruit, nuts, and other plants if an area has been overhunted. Travelers who are respectful of the plants and animals in tribal territory are left alone, but those who disrespect nature or try to build permanent settlements of any kind will become a target of the tribe’s wrath.</p>
+
+      <h4>CENTAURS IN THYLEA</h4>
+      <p>Centaurs are distrustful of the civilized races. In the First War that raged five centuries ago, thousands of centaurs were killed by the invading Dragonlords, and the centaurs have never forgotten or forgiven. The distrust is mutual, especially as centaur tribes are now flocking to the banner of Sydon and raiding outlying farms. Centaurs that enter a Thylean town or city will find that they are tolerated but kept under constant watch.</p>
+      <p class="indent">The centaurs tend to worship the mother goddess, but they will sometimes offer prayers to one of the titans, Sydon or Lutheria. They never worship the Five.</p>
+
+      <h4>CENTAUR NAMES</h4>
+      <p>Centaurs have names that are specific to their race. These names can often be difficult for members of other races to pronounce, so they can adopt nicknames when traveling with a band of non-centaurs.</p>
+      <p>
+        <span class="feature">Male Names:</span>Agrius (Agri), Amycus (Amy), Asbolus (Az), Bienor, Chiron, Cyllarus (Cyl), Dictys, Eurytus (Tus), Elatus, Eurytion (Yuri), Hylaeus (Hyla), Nessus, Perimedes (Peri), Pholus, Rhoetus (Rote), and Thaumas (Tom).<br/>
+        <span class="feature">Female Names:</span>Agaria, Biano, Cylla, Diena, Eura, Hylonome (Hylo), Heranae (Hera), Nessicana (Nessie), Nara, Ponadata (Pona), Rhaelatisis (Rala), Rhaena (Rain), and Seranu (Sara).
+      </p>
+
+      <h4>CENTAUR TRAITS</h4>
+      <p>Centaurs have the following racial traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Strength score increases by 2, and your Wisdom score increases by 1.<br/>
+        <span class="feature">Age.</span>Centaurs mature at the same rate as humans.<br/>
+        <span class="feature">Alignment.</span>Centaurs have a tendency toward good. As a tribal people, they don’t lean toward the freedom of a chaotic alignment, but they don’t obey laws that they feel are unjust or ineffective. They lean toward neutral.<br/>
+        <span class="feature">Size.</span>Centaurs range from 6'6" to 7 feet in height and weigh between 700 and 900 pounds. Your size is Medium, but you tower over most other races.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 40 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and Sylvan.<br/>
+        <span class="feature">Charge.</span>If you move 30 feet straight toward a target and then hit them with a melee attack on the same turn, the target takes an extra 1d6 damage from the first attack.<br/>
+        <span class="feature">Mountable.</span>As a bonus action on your turn, you may allow a single willing ally within 5 feet of you to hitch a brief ride on your back. They are carried on your back until the end of your turn, at which point they must disembark within 5 feet of you. While being carried, your rider is not considered to be mounted and they are not vulnerable to attacks of opportunity. Your rider must be a bipedal creature of your size or smaller.<br/>
+        <span class="feature">Quadrapedal Stride.</span>Climbing or maneuvering in tight spaces is considered difficult terrain for you.
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+      <set name="names" type="male">Agrius (Agri), Amycus (Amy), Asbolus (Az), Bienor, Chiron, Cyllarus (Cyl), Dictys, Eurytus (Tus), Elatus, Eurytion (Yuri), Hylaeus (Hyla), Nessus, Perimedes (Peri), Pholus, Rhoetus (Rote), and Thaumas (Tom)</set>
+      <set name="names" type="female">Agaria, Biano, Cylla, Diena, Eura, Hylonome (Hylo), Heranae (Hera), Nessicana (Nessie), Nara, Ponadata (Pona), Rhaelatisis (Rala), Rhaena (Rain), and Seranu (Sara)</set>
+      <set name="names-format">{{name}}</set>
+      <set name="height">6'10"</set>
+      <set name="weight">800 lb.</set>
+    </setters>
+    <rules>
+      <stat name="strength" value="2"/>
+      <stat name="wisdom" value="1"/>
+      <stat name="innate speed" value="40" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <grant type="Language" id="ID_LANGUAGE_SYLVAN" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_CHARGE" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_MOUNTABLE" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_QUADRAPEDAL_STRIDE" />
+    </rules>
+  </element>
+
+  <element name="Charge" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_CHARGE">
+    <supports />
+    <description>
+      <p>If you move 30 feet straight toward a target and then hit them with a melee attack on the same turn, the target takes an extra 1d6 damage from the first attack.</p>
+    </description>
+    <sheet>
+      <description>If you move 30 feet straight toward a target and then hit them with a melee attack on the same turn, the target takes an extra 1d6 damage from the first attack.</description>
+    </sheet>
+  </element>
+
+  <element name="Mountable" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_MOUNTABLE">
+    <supports />
+    <description>
+      <p>As a bonus action on your turn, you may allow a single willing ally within 5 feet of you to hitch a brief ride on your back. They are carried on your back until the end of your turn, at which point they must disembark within 5 feet of you. While being carried, your rider is not considered to be mounted and they are not vulnerable to attacks of opportunity. Your rider must be a bipedal creature of your size or smaller.</p>
+    </description>
+    <sheet>
+      <description action="Bonus Action">You may allow a single willing ally within 5 feet of you to hitch a brief ride on your back. They are carried on your back until the end of your turn, at which point they must disembark within 5 feet of you. While being carried, your rider is not considered to be mounted and they are not vulnerable to attacks of opportunity. Your rider must be a bipedal creature of your size or smaller.</description>
+    </sheet>
+  </element>
+
+  <element name="Quadrapedal Stride" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_CENTAUR_QUADRAPEDAL_STRIDE">
+    <supports />
+    <description>
+      <p>Climbing or maneuvering in tight spaces is considered difficult terrain for you.</p>
+    </description>
+    <sheet>
+      <description>Climbing or maneuvering in tight spaces is considered difficult terrain for you.</description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleancentaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleancentaur.xml" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Medusa" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MEDUSA">
-    <supports />
     <description>
       <p class="flavor">Medusa are humanoids that have made a bargain with dark powers to achieve beauty, eternal youth, great wealth, or some other mortal desire. As a consequence, their hair has been replaced with snakes, and their eyes have the power to petrify the unwary. They are despised and shunned by all other mortal races, and they must be careful to hide their identity when traveling in the civilized places of the world.
       </p>
@@ -62,7 +61,6 @@
   </element>
 
   <element name="Cursed" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_CURSED">
-    <supports />
     <description>
       <p>You are afflicted by the <i>curse of the medusa</i>, but your transformation is already complete. Your curse can only be ended with the wish spell. If your curse ends, then your race changes to whichever race you were before you became cursed (usually a human).</p>
     </description>
@@ -72,7 +70,6 @@
   </element>
 
   <element name="Snake Hair" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_HAIR">
-    <supports />
     <description>
       <p>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to your proficiency modifier + your Dexterity modifier. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</p>
     </description>
@@ -87,7 +84,6 @@
   </element>
 
   <element name="Snake Blood" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_BLOOD">
-    <supports/>
     <description>
       <p>You have advantage on saving throws against spells and abilities that inflict the poisoned condition.</p>
     </description>
@@ -97,7 +93,6 @@
   </element>
 
   <element name="Petrifying Gaze" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_PETRIFYING_GAZE">
-    <supports />
     <description>
       <p>
         Starting at 5th level, you can use your action to force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.<br/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleanmedusa.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml" />
 		</update>
@@ -42,9 +41,7 @@
       </p>
     </description>
     <sheet display="false" />
-    <setters>
-      
-    </setters>
+    <setters />
     <rules>
       <stat name="dexterity" value="2"/>
       <stat name="intelligence" value="1"/>
@@ -77,7 +74,6 @@
       <description>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to +{{snake hair:bonus}}. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</description>
     </sheet>
     <rules>
-      <stat name="snake hair:bonus" value="0" />
       <stat name="snake hair:bonus" value="proficiency" />
       <stat name="snake hair:bonus" value="dexterity:modifier" />
     </rules>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
@@ -1,0 +1,122 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleanmedusa.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml" />
+		</update>
+	</info>
+  <element name="Thylean Medusa" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MEDUSA">
+    <supports />
+    <description>
+      <p class="flavor">Medusa are humanoids that have made a bargain with dark powers to achieve beauty, eternal youth, great wealth, or some other mortal desire. As a consequence, their hair has been replaced with snakes, and their eyes have the power to petrify the unwary. They are despised and shunned by all other mortal races, and they must be careful to hide their identity when traveling in the civilized places of the world.
+      </p>
+
+      <h4>LEGEND OF THE MEDUSA</h4>
+      <p>Thousands of years ago, a woman came to Thylea seeking her fortune. When the creatures of that land asked her from whence she came, she would only say, "I am from the land of the Gorgons." In those days, Thylea was rich in natural beauty but poor in wealth. But the woman would not be deterred.</p>
+      <p class="indent">First, the woman searched the steppes and mountains, and she came to the centaurs, asking, "Where may I find gems and jewels to rival the stars?" The centaurs offered her a shank of lamb and said, "Why seek gems and jewels when the stars are free to everyone?" Disappointed, she cast away the food and left the centaurs to their star-gazing.</p>
+      <p class="indent">Then the woman searched the forests, and she came to the satyrs, asking, "Where may I find rivers of gold and silver that flow like fountains?" The satyrs offered her a goblet of wine and said, "Gold and silver make a very poor feast. Wouldn’t you rather join us for a song and a drink?" Disappointed again, the woman cast away the goblet and left the satyrs to their revelry.</p>
+      <p class="indent">Now, the woman wandered high and low, seeking her fortune to no avail, and finally she came upon three women weaving at a loom. She said, "I wish for riches beyond the imagination of all the creatures that haunt this accursed land." The three women, who were the Fates, warned her. "Is this truly what you desire? You may have it, but the price will be high.” And the woman answered, “When I am rich, I shall have no trouble paying any price.” And the Fates said, "So be it."</p>
+      <p class="indent">The woman’s eyes suddenly gleamed like golden coins, and wherever she turned her gaze, creatures were turned to stone. "So that none may rob you of your treasure," said the Fates. The woman’s hair grew long and sinuous, slithering and scaled like snakes. "So that always you will have the company of hearts as cold as your own." And finally, the woman’s hands were filled with gems and coins that were beautiful beyond the reckoning of stars or songs. Her name was Medusa, and she was the namesake of her curse, which afflicts many such mortals with more ambition than sense.</p>
+
+      <h4>CURSED BY DARK POWERS</h4>
+      <p>Medusae have typically made bargains with some sort of fiend or fiendish power, but in some cases, they are oathbreakers who have displeased the gods or the Fates. Either way, they have been afflicted with the curse of the medusa as punishment, and recovery from the curse is not possible without the use of powerful magic. In some cases, even the greater restoration spell may not be enough to break the curse. But in many other cases, the medusa simply embraces the curse as part of her identity. Children born to medusae are also affected by the curse.</p>
+
+      <h4>OPHIDIAN SCHEMERS</h4>
+      <p>Medusae are known to spend much of their time plotting against those who rival them in wealth, power, or beauty. Some medusae name their snakes and speak to them as if they were speaking to cherished pets or loved ones. Others are ashamed of their curse and seek to break it. Medusae must train themselves to never gaze into a mirror or stare at their reflection, for in an ironic twist of fate, they are vulnerable to their own petrifying gaze.</p>
+
+      <h4>MEDUSA TRAITS</h4>
+      <p>Medusae have the following racial traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Dexterity score increases by 2, and your Intelligence score increases by 1.<br/>
+        <span class="feature">Age.</span>Medusae are not born—they are made. When a humanoid is afflicted by the curse of the medusa, they gradually transform into a snake-haired monstrosity. Once transformed, they may live for a thousand years, but most are hunted down and killed long before then.<br/>
+        <span class="feature">Alignment.</span>Civilized medusae tend toward neutral or lawful evil alignments, because they must find ways to survive on the fringes of society. They must be careful to cooperate with others who will suffer the company of one who is cursed by the gods. Medusae who give into their anger eventually lose control of themselves and become true monsters.<br/>
+        <span class="feature">Size.</span>Medusae are the same size and build as humans. Your size is Medium.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 30 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and one language of your choice.<br/>
+        <span class="feature">Darkvision.</span>Your eyes are adapted to dark places, giving you darkvision out to 60 ft.<br/>
+        <span class="feature">Cursed.</span>You are afflicted by the <i>curse of the medusa</i>, but your transformation is already complete. Your curse can only be ended with the <i>wish</i> spell. If your curse ends, then your race changes to whichever race you were before you became cursed (usually a human).<br/>
+        <span class="feature">Snake Hair.</span>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to your proficiency modifier + your Dexterity modifier. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.<br/>
+        <span class="feature">Snake Blood.</span>You have advantage on saving throws against spells and abilities that inflict the poisoned condition.<br/>
+        <span class="feature">Petrifying Gaze.</span>Starting at 5th level, you can use your action to force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.<br/>
+        Starting at 10th level, the DC for this saving throw increases to 10. At 15th level, the DC increases to 12. At 20th level, the DC increases to 14.
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+      
+    </setters>
+    <rules>
+      <stat name="dexterity" value="2"/>
+      <stat name="intelligence" value="1"/>
+      <stat name="innate speed" value="30" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Vision" id="ID_VISION_DARKVISION" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <select type="Language" name="Language (Thylean Medusa)" supports="Starting" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_CURSED" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_HAIR" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_BLOOD" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_PETRIFYING_GAZE" />
+    </rules>
+  </element>
+
+  <element name="Cursed" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_CURSED">
+    <supports />
+    <description>
+      <p>You are afflicted by the <i>curse of the medusa</i>, but your transformation is already complete. Your curse can only be ended with the wish spell. If your curse ends, then your race changes to whichever race you were before you became cursed (usually a human).</p>
+    </description>
+    <sheet>
+      <description>You are afflicted by the <i>curse of the medusa</i>, but your transformation is already complete. Your curse can only be ended with the <i>wish</i> spell. If your curse ends, then your race changes to whichever race you were before you became cursed (usually a human).</description>
+    </sheet>
+  </element>
+
+  <element name="Snake Hair" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_HAIR">
+    <supports />
+    <description>
+      <p>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to your proficiency modifier + your Dexterity modifier. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</p>
+    </description>
+    <sheet>
+      <description>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to +{{snake hair:bonus}}. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</description>
+    </sheet>
+    <rules>
+      <stat name="snake hair:bonus" value="0" />
+      <stat name="snake hair:bonus" value="proficiency" />
+      <stat name="snake hair:bonus" value="dexterity:modifier" />
+    </rules>
+  </element>
+
+  <element name="Snake Blood" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_SNAKE_BLOOD">
+    <supports/>
+    <description>
+      <p>You have advantage on saving throws against spells and abilities that inflict the poisoned condition.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on saving throws against spells and abilities that inflict the poisoned condition.</description>
+    </sheet>
+  </element>
+
+  <element name="Petrifying Gaze" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MEDUSA_PETRIFYING_GAZE">
+    <supports />
+    <description>
+      <p>
+        Starting at 5th level, you can use your action to force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.<br/>
+        Starting at 10th level, the DC for this saving throw increases to 10. At 15th level, the DC increases to 12. At 20th level, the DC increases to 14.
+      </p>
+    </description>
+    <sheet>
+      <description level="5">
+        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+      </description>
+      <description level="10">
+        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 10 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+      </description>
+      <description level="15">
+        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 12 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+      </description>
+      <description level="20">
+        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 14 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+      </description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanmedusa.xml
@@ -7,22 +7,17 @@
 	</info>
   <element name="Thylean Medusa" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MEDUSA">
     <description>
-      <p class="flavor">Medusa are humanoids that have made a bargain with dark powers to achieve beauty, eternal youth, great wealth, or some other mortal desire. As a consequence, their hair has been replaced with snakes, and their eyes have the power to petrify the unwary. They are despised and shunned by all other mortal races, and they must be careful to hide their identity when traveling in the civilized places of the world.
-      </p>
-
+      <p class="flavor">Medusa are humanoids that have made a bargain with dark powers to achieve beauty, eternal youth, great wealth, or some other mortal desire. As a consequence, their hair has been replaced with snakes, and their eyes have the power to petrify the unwary. They are despised and shunned by all other mortal races, and they must be careful to hide their identity when traveling in the civilized places of the world.</p>
       <h4>LEGEND OF THE MEDUSA</h4>
       <p>Thousands of years ago, a woman came to Thylea seeking her fortune. When the creatures of that land asked her from whence she came, she would only say, "I am from the land of the Gorgons." In those days, Thylea was rich in natural beauty but poor in wealth. But the woman would not be deterred.</p>
       <p class="indent">First, the woman searched the steppes and mountains, and she came to the centaurs, asking, "Where may I find gems and jewels to rival the stars?" The centaurs offered her a shank of lamb and said, "Why seek gems and jewels when the stars are free to everyone?" Disappointed, she cast away the food and left the centaurs to their star-gazing.</p>
       <p class="indent">Then the woman searched the forests, and she came to the satyrs, asking, "Where may I find rivers of gold and silver that flow like fountains?" The satyrs offered her a goblet of wine and said, "Gold and silver make a very poor feast. Wouldn’t you rather join us for a song and a drink?" Disappointed again, the woman cast away the goblet and left the satyrs to their revelry.</p>
       <p class="indent">Now, the woman wandered high and low, seeking her fortune to no avail, and finally she came upon three women weaving at a loom. She said, "I wish for riches beyond the imagination of all the creatures that haunt this accursed land." The three women, who were the Fates, warned her. "Is this truly what you desire? You may have it, but the price will be high.” And the woman answered, “When I am rich, I shall have no trouble paying any price.” And the Fates said, "So be it."</p>
       <p class="indent">The woman’s eyes suddenly gleamed like golden coins, and wherever she turned her gaze, creatures were turned to stone. "So that none may rob you of your treasure," said the Fates. The woman’s hair grew long and sinuous, slithering and scaled like snakes. "So that always you will have the company of hearts as cold as your own." And finally, the woman’s hands were filled with gems and coins that were beautiful beyond the reckoning of stars or songs. Her name was Medusa, and she was the namesake of her curse, which afflicts many such mortals with more ambition than sense.</p>
-
       <h4>CURSED BY DARK POWERS</h4>
       <p>Medusae have typically made bargains with some sort of fiend or fiendish power, but in some cases, they are oathbreakers who have displeased the gods or the Fates. Either way, they have been afflicted with the curse of the medusa as punishment, and recovery from the curse is not possible without the use of powerful magic. In some cases, even the greater restoration spell may not be enough to break the curse. But in many other cases, the medusa simply embraces the curse as part of her identity. Children born to medusae are also affected by the curse.</p>
-
       <h4>OPHIDIAN SCHEMERS</h4>
       <p>Medusae are known to spend much of their time plotting against those who rival them in wealth, power, or beauty. Some medusae name their snakes and speak to them as if they were speaking to cherished pets or loved ones. Others are ashamed of their curse and seek to break it. Medusae must train themselves to never gaze into a mirror or stare at their reflection, for in an ironic twist of fate, they are vulnerable to their own petrifying gaze.</p>
-
       <h4>MEDUSA TRAITS</h4>
       <p>Medusae have the following racial traits.</p>
       <p>
@@ -40,7 +35,7 @@
         Starting at 10th level, the DC for this saving throw increases to 10. At 15th level, the DC increases to 12. At 20th level, the DC increases to 14.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Medusa" display="false" />
     <setters />
     <rules>
       <stat name="dexterity" value="2"/>
@@ -71,7 +66,7 @@
       <p>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to your proficiency modifier + your Dexterity modifier. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</p>
     </description>
     <sheet>
-      <description>You can attack with your snake hair. This is a melee weapon attack with an attack bonus equal to +{{snake hair:bonus}}. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</description>
+      <description>You can attack with your snake hair. This is a melee weapon attack with a +{{snake hair:bonus}} attack bonus. It does 1d6 piercing damage on a hit, and your target must make a DC 12 Constitution saving throw or else they are poisoned until the beginning of your next turn.</description>
     </sheet>
     <rules>
       <stat name="snake hair:bonus" value="proficiency" />
@@ -95,18 +90,18 @@
         Starting at 10th level, the DC for this saving throw increases to 10. At 15th level, the DC increases to 12. At 20th level, the DC increases to 14.
       </p>
     </description>
-    <sheet>
+    <sheet action="Action">
       <description level="5">
-        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+        You can force a creature within 30 feet that can see your eyes to make a DC 8 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
       </description>
       <description level="10">
-        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 10 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+        You can force a creature within 30 feet that can see your eyes to make a DC 10 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
       </description>
       <description level="15">
-        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 12 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+        You can force a creature within 30 feet that can see your eyes to make a DC 12 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
       </description>
       <description level="20">
-        You can use your action to force a creature within 30 feet that can see your eyes to make a DC 14 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
+        You can force a creature within 30 feet that can see your eyes to make a DC 14 Constitution saving throw. On a failure, the creature is paralyzed until the end of its next turn. On your turn, you can use your bonus action to force the same creature to repeat this saving throw with disadvantage. Each time it fails, it is paralyzed again until the end of its next turn. When a creature is paralyzed in this way for the third time in a span of 10 minutes, it is instantly petrified.
       </description>
     </sheet>
   </element>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
@@ -7,27 +7,20 @@
 	</info>
   <element name="Thylean Minotaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MINOTAUR">
     <description>
-      <p class="flavor">
-        Minotaurs are the descendants of an ancient tribe of humans who were cursed by the gods, transforming them into half-human, half-bull monstrosities. Although they are widely dismissed as unthinking brutes, they are in fact as diverse and as intelligent as any other race.
-      </p>
-
+      <p class="flavor">Minotaurs are the descendants of an ancient tribe of humans who were cursed by the gods, transforming them into half-human, half-bull monstrosities. Although they are widely dismissed as unthinking brutes, they are in fact as diverse and as intelligent as any other race.</p>
       <h4>LEGEND OF THE MINOTAURS</h4>
       <p>Over a thousand years ago, a tribe of humans washed ashore in Thylea and came to live in the southern hills of the Aresian peninsula. Here, they laid foundations for a city and called it Minos. But not one man or woman among them had the strength to till the hard, rocky soil. As fate would have it, they discovered a magnificent bull that could pull a plow through any terrain for days without resting. Using the bull’s great strength, they were able to produce bountiful crops with which to survive the first winter.</p>
       <p class="indent">Over time, the people of the tribe began to venerate the bull, crowning him as the god of the harvest. When Sydon learned of this, he was furious. He threw curses down upon the settlers and transformed them into bulls, in mockery of their insolence. Each of them was harnessed to a plow and forced to tread the same winding, geometric path, until that path became a deep, labyrinthian gorge. Eventually, the plows broke, and the people of Minos slowly began to stand upright again—but their faces had been forever changed by the curse.</p>
-      <p class="indent">The people of the tribe came to be called minotaurs—the bulls of Minos—and they have never fully shed their bull-like demeanors. Some of them merely have horns and a snout-like nose, while others have the entire upper torso of a bull. Some continued to dwell in the labyrinth, while others left to explore the far reaches of Thylea. Over the centuries, they have come to view their own cursed existence as the will of the Fates.</p>
-      
+      <p class="indent">The people of the tribe came to be called minotaurs—the bulls of Minos—and they have never fully shed their bull-like demeanors. Some of them merely have horns and a snout-like nose, while others have the entire upper torso of a bull. Some continued to dwell in the labyrinth, while others left to explore the far reaches of Thylea. Over the centuries, they have come to view their own cursed existence as the will of the Fates.</p>      
       <h4>WARRIOR BULLS</h4>
       <p>Minotaurs possess uncommon strength, making them excellent warriors. The curse infuses their bodies with the power of a bull at all times, and their muscles seldom relax, even when they are drunk or asleep. In battle, minotaurs sometimes lose control of their emotions and fly into a rage. When this happens, the curse takes over, transforming them back into a full-fledged bull for a short period of time.</p>
-
       <h4>OATHBOUND SLAVES</h4>
       <p>Minotaurs are widely shunned, because they are believed to be unthinking brutes who have been cursed by the gods. Most minotaurs gather together to form small farming or fishing communities, far from civilization. The only way that most minotaurs can find work in cities and villages is to swear oaths of service that effectively reduce them to the status of slaves. Many bear this humiliation with stoic grit, but others resort to banditry rather than submit to the unreasonable demands of cowardly superstition.</p>
-
       <h4>MINOTAUR NAMES</h4>
       <p>Minotaurs generally prefer names that are short and simple. They typically punctuate their names with a snort or a sharp exhalation of air through their nostrils. When someone omits this part of their name, they become annoyed.</p>
       <p>
         <span class="feature">Names:</span>Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark
       </p>
-      
       <h4>MINOTAUR TRAITS</h4>
       <p>Minotaurs have the following racial traits.</p>
       <p>
@@ -43,7 +36,7 @@
         <span class="feature">Cursed Transformation.</span>Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.<br/>
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Minotaur" display="false" />
     <setters>
       <set name="names" type="custom">Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark</set>
       <set name="names-format">{{name}}</set>
@@ -69,7 +62,7 @@
       <p>Despite your powerful demeanor, you have a delicate nose. You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.</p>
     </description>
     <sheet>
-      <description>You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.</description>
+      <description>You have advantage on Perception checks that rely on smell, and you can detect strong odors from up to six miles away.</description>
     </sheet>
   </element>
 
@@ -96,17 +89,11 @@
 
   <element name="Cursed Transformation" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_CURSED_TRANSFORMATION">
     <description>
-      <p>
-        Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.
-      </p>
+      <p>Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.</p>
     </description>
-    <sheet>
-      <description level="5" action="Bonus Action" usage="1/Long Rest">
-        Transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.
-      </description>
-      <description level="9" action="Bonus Action" usage="1/Long Rest">
-        Transform yourself into a <b>dire bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.
-      </description>
+    <sheet action="Bonus Action" usage="1/Long Rest">
+      <description>Transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.</description>
+      <description level="9">Transform yourself into a <b>dire bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.</description>
     </sheet>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
@@ -1,0 +1,115 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleanminotaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml" />
+		</update>
+	</info>
+  <element name="Thylean Minotaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MINOTAUR">
+    <supports />
+    <description>
+      <p class="flavor">
+        Minotaurs are the descendants of an ancient tribe of humans who were cursed by the gods, transforming them into half-human, half-bull monstrosities. Although they are widely dismissed as unthinking brutes, they are in fact as diverse and as intelligent as any other race.
+      </p>
+
+      <h4>LEGEND OF THE MINOTAURS</h4>
+      <p>Over a thousand years ago, a tribe of humans washed ashore in Thylea and came to live in the southern hills of the Aresian peninsula. Here, they laid foundations for a city and called it Minos. But not one man or woman among them had the strength to till the hard, rocky soil. As fate would have it, they discovered a magnificent bull that could pull a plow through any terrain for days without resting. Using the bull’s great strength, they were able to produce bountiful crops with which to survive the first winter.</p>
+      <p class="indent">Over time, the people of the tribe began to venerate the bull, crowning him as the god of the harvest. When Sydon learned of this, he was furious. He threw curses down upon the settlers and transformed them into bulls, in mockery of their insolence. Each of them was harnessed to a plow and forced to tread the same winding, geometric path, until that path became a deep, labyrinthian gorge. Eventually, the plows broke, and the people of Minos slowly began to stand upright again—but their faces had been forever changed by the curse.</p>
+      <p class="indent">The people of the tribe came to be called minotaurs—the bulls of Minos—and they have never fully shed their bull-like demeanors. Some of them merely have horns and a snout-like nose, while others have the entire upper torso of a bull. Some continued to dwell in the labyrinth, while others left to explore the far reaches of Thylea. Over the centuries, they have come to view their own cursed existence as the will of the Fates.</p>
+      
+      <h4>WARRIOR BULLS</h4>
+      <p>Minotaurs possess uncommon strength, making them excellent warriors. The curse infuses their bodies with the power of a bull at all times, and their muscles seldom relax, even when they are drunk or asleep. In battle, minotaurs sometimes lose control of their emotions and fly into a rage. When this happens, the curse takes over, transforming them back into a full-fledged bull for a short period of time.</p>
+
+      <h4>OATHBOUND SLAVES</h4>
+      <p>Minotaurs are widely shunned, because they are believed to be unthinking brutes who have been cursed by the gods. Most minotaurs gather together to form small farming or fishing communities, far from civilization. The only way that most minotaurs can find work in cities and villages is to swear oaths of service that effectively reduce them to the status of slaves. Many bear this humiliation with stoic grit, but others resort to banditry rather than submit to the unreasonable demands of cowardly superstition.</p>
+
+      <h4>MINOTAUR NAMES</h4>
+      <p>Minotaurs generally prefer names that are short and simple. They typically punctuate their names with a snort or a sharp exhalation of air through their nostrils. When someone omits this part of their name, they become annoyed.</p>
+      <p>
+        <span class="feature">Names:</span>Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark
+      </p>
+      
+      <h4>MINOTAUR TRAITS</h4>
+      <p>Minotaurs have the following racial traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Strength score increases by 2, and your Constitution score increases by 1.<br/>
+        <span class="feature">Age.</span>Minotaurs mature at the same rate as humans and live to about the same ages.<br/>
+        <span class="feature">Alignment.</span>Minotaurs tend toward neutral alignments. Most are stoic and proudly stubborn, refusing to be moved by notions of good or evil.<br/>
+        <span class="feature">Size.</span>Minotaurs range from 6 to 8 feet in height. They weigh between 200 and 400 pounds. Your size is Medium.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 40 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and Abyssal.<br/>
+        <span class="feature">Keen Snout.</span>Despite your powerful demeanor, you have a delicate nose. You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.<br/>
+        <span class="feature">Labyrinthine Vision.</span>Your eyes are adapted to the dark conditions of deep canyons and underground labyrinths, giving you darkvision out to 60 ft. You have advantage on skill checks made to solve maze-like puzzles. Additionally, you automatically succeed on saving throws against <i>maze</i> and <i>hypnotic pattern</i>.<br/>
+        <span class="feature">Colorblindness.</span>You see the world in shades of red and grey, leaving you incapable of discerning any color except for very bright reds.<br/>
+        <span class="feature">Cursed Transformation.</span>Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.<br/>
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+
+    </setters>
+    <rules>
+      <stat name="strength" value="2"/>
+      <stat name="constitution" value="1"/>
+      <stat name="innate speed" value="40" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <grant type="Language" id="ID_LANGUAGE_ABYSSAL" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_KEEN_SNOUT" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_LABYRINTHINE_VISION" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_COLORBLINDNESS" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_CURSED_TRANSFORMATION" />
+    </rules>
+  </element>
+
+  <element name="Keen Snout" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_KEEN_SNOUT">
+    <supports />
+    <description>
+      <p>Despite your powerful demeanor, you have a delicate nose. You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.</description>
+    </sheet>
+  </element>
+
+  <element name="Labyrinthine Vision" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_LABYRINTHINE_VISION">
+    <supports />
+    <description>
+      <p>Your eyes are adapted to the dark conditions of deep canyons and underground labyrinths, giving you darkvision out to 60 ft. You have advantage on skill checks made to solve maze-like puzzles. Additionally, you automatically succeed on saving throws against maze and hypnotic pattern.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on skill checks made to solve maze-like puzzles. Additionally, you automatically succeed on saving throws against <i>maze</i> and <i>hypnotic pattern</i>.</description>
+    </sheet>
+    <rules>
+      <grant type="Vision" id="ID_VISION_DARKVISION" />
+    </rules>
+  </element>
+
+  <element name="Colorblindness" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_COLORBLINDNESS">
+    <supports/>
+    <description>
+      <p>You see the world in shades of red and grey, leaving you incapable of discerning any color except for very bright reds.</p>
+    </description>
+    <sheet>
+      <description>You see the world in shades of red and grey, leaving you incapable of discerning any color except for very bright reds.</description>
+    </sheet>
+  </element>
+
+  <element name="Cursed Transformation" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_CURSED_TRANSFORMATION">
+    <supports />
+    <description>
+      <p>
+        Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.
+      </p>
+    </description>
+    <sheet>
+      <description level="5" action="Bonus Action" usage="1/Long Rest">
+        Transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.
+      </description>
+      <description level="9" action="Bonus Action" usage="1/Long Rest">
+        Transform yourself into a <b>dire bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability automatically triggers if you suffer prolonged exposure to very bright shades of red.
+      </description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Minotaur" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_MINOTAUR">
-    <supports />
     <description>
       <p class="flavor">
         Minotaurs are the descendants of an ancient tribe of humans who were cursed by the gods, transforming them into half-human, half-bull monstrosities. Although they are widely dismissed as unthinking brutes, they are in fact as diverse and as intelligent as any other race.
@@ -64,7 +63,6 @@
   </element>
 
   <element name="Keen Snout" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_KEEN_SNOUT">
-    <supports />
     <description>
       <p>Despite your powerful demeanor, you have a delicate nose. You have advantage on Wisdom (Perception) checks that rely on smell, and you can detect strong odors from up to six miles away.</p>
     </description>
@@ -74,7 +72,6 @@
   </element>
 
   <element name="Labyrinthine Vision" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_LABYRINTHINE_VISION">
-    <supports />
     <description>
       <p>Your eyes are adapted to the dark conditions of deep canyons and underground labyrinths, giving you darkvision out to 60 ft. You have advantage on skill checks made to solve maze-like puzzles. Additionally, you automatically succeed on saving throws against maze and hypnotic pattern.</p>
     </description>
@@ -87,7 +84,6 @@
   </element>
 
   <element name="Colorblindness" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_COLORBLINDNESS">
-    <supports/>
     <description>
       <p>You see the world in shades of red and grey, leaving you incapable of discerning any color except for very bright reds.</p>
     </description>
@@ -97,7 +93,6 @@
   </element>
 
   <element name="Cursed Transformation" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_MINOTAUR_CURSED_TRANSFORMATION">
-    <supports />
     <description>
       <p>
         Starting at 5th level, you may use your bonus action to transform yourself into a <b>bull</b> using the rules of the <i>polymorph</i> spell (no concentration required). This ability recharges after a long rest. This ability automatically triggers if you suffer prolonged exposure to very bright shades of red. Starting at 9th level, this ability transforms you into a <b>dire bull</b>.

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleanminotaur.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml" />
 		</update>
@@ -46,7 +45,10 @@
     </description>
     <sheet display="false" />
     <setters>
-
+      <set name="names">Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark</set>
+      <set name="names-format">{{name}}</set>
+      <set name="height">7'</set>
+      <set name="weight">300 lb.</set>
     </setters>
     <rules>
       <stat name="strength" value="2"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleanminotaur.xml
@@ -45,7 +45,7 @@
     </description>
     <sheet display="false" />
     <setters>
-      <set name="names">Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark</set>
+      <set name="names" type="custom">Arxan, Braz, Dregxa, Elagore, Garnox, Horus, Kath, Luth, Manx, Parth, Raxus, Steth, Torag, Zark</set>
       <set name="names-format">{{name}}</set>
       <set name="height">7'</set>
       <set name="weight">300 lb.</set>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleannymph.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml" />
 		</update>
@@ -48,7 +47,9 @@
     </description>
     <sheet display="false" />
     <setters>
-
+      <set name="names" type="male">Celano, Elion, Eratheis, Hyllis, Limnade, Linos, Myrmex, Olbia, Pega, Potameid, Pyron, Taygete</set>
+      <set name="names" type="female">Aegle, Alcyone, Arethusa, Asterope, Brettia, Brisa, Calybe, Crinae, Crimisa, Dodone, Electra, Erythia, Hesperia, Himalia, Oeneis, Laodice, Maia, Merope, Polydora, Rhene, Semestra</set>
+      <set name="names-format">{{name}}</set>
     </setters>
     <rules>
       <stat name="charisma" value="2"/>
@@ -218,17 +219,18 @@
       <p>You can breathe underwater, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>fog cloud</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>water walk</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
     </description>
     <sheet>
-      <description>You can breathe underwater, and you have a swimming speed of 40 ft.</description>
+      <description>You can breathe underwater.</description>
       <description level="3">
-        You can breathe underwater, and you have a swimming speed of 40 ft.<br/>
+        You can breathe underwater.<br/>
         1/short rest. <i>Fog cloud</i>.
       </description>
       <description level="7">
-        You can breathe underwater, and you have a swimming speed of 40 ft.<br/>
+        You can breathe underwater.<br/>
         1/short rest. <i>Fog cloud</i>, and <i>Water walk</i>.
       </description>
     </sheet>
     <rules>
+      <stat name="innate speed:swim" value="40" />
       <grant type="Spell" id="ID_PHB_SPELL_FOG_CLOUD" level="3" />
       <grant type="Spell" id="ID_PHB_SPELL_WATER_WALK" level="7" />
     </rules>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
@@ -1,0 +1,277 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleannymph.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml" />
+		</update>
+	</info>
+  <element name="Thylean Nymph" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_NYMPH">
+    <supports />
+    <description>
+      <p class="flavor">
+        Nymphs are fey spirits that manifest from the beauty of the elemental forces of creation. There are many kinds of nymphs—dryads of the forests, naiads of the rivers, oreads of the mountains, aurae of the night sky, and nereids of the sea. They have walked the earth for millennia, ever since the Great Mother awakened them from the trees, waters, rocks, and breezes.
+      </p>
+      <p class="indent">
+        Nymphs are most at home in nature, but they have been known to disguise themselves and live amongst mortals, for they are desperately curious about the civilized world. In spite of this, they often have a difficult time comprehending the day-to-day struggle of civilized existence. Their charms are such that they may inadvertently seduce and domesticate mortal ‘pets’ who see to their every need, leaving them somewhat puzzled by the ugliness and hardship that seems to pervade cities.
+      </p>
+
+      <h4>LEGEND OF THE NYMPHS</h4>
+      <p>There was once a river running through the mountains. None can say which river or which mountains, for this was so long ago that the land has rolled and shifted so as to become unrecognizable in the time since. The mountains were blanketed in a soft powder of white snow, and as the snow melted, it crept along the ground and joined together into streams of water, which trickled along the rocks and formed a river. And the river coursed down through a forest, emptying into the ocean. So it went for eons.</p>
+      <p class="indent">But then one day, the snow on the mountains had a thought. “Am I alike to the water in the streams?” And so also did the water in the river begin to wonder, “Am I alike to the roots of the trees?” They were curious, but it seemed that they would never know the answer, for just as the snow went to inspect the streams, it became the water, and just as the water went to inspect the trees, it became the roots. And so it went for eons.</p>
+      <p class="indent">Eventually, the Great Mother herself became aware of these questions. Holding the world in her embrace, she felt the curiosity of the elements rippling and vibrating across its surface, anxious for answers. And so, she loosened her grip—just slightly. The rippling thoughts of the snow and the waters and the rocks and the trees took shape, and their shapes were beautiful, for they were curiosity made manifest. These were the first nymphs.</p>
+      
+      <h4>BEAUTIFUL AND DIVERSE</h4>
+      <p>Nymphs are famed for their feminine charms, but they are not exclusively female. Some are awakened from the elements with a mix of masculine and feminine features, and others are quintessential specimens of male splendor. As fey creatures, nymphs like little less than to be nailed down by the crude shackles of mortal language. They come in as many shapes and forms as the earth itself. The only physical trait that all of them have in common is an awe-inspiring beauty.</p>
+
+      <h4>CURIOUS AND POSSESSIVE</h4>
+      <p>Nymphs have an insatiable desire to learn as much as possible about both the natural and the civilized world. Because most have had eons to discover the splendor of nature, it is the civilized world that interests them the most. However, they are not usually very accustomed to mortal culture, and so they may think of men and women as interesting baubles to be collected and admired. Even civilized nymphs tend to cherish their friends and acquaintances as ‘pets’ to be manicured and proudly exhibited. They are not above bragging about their collection—or fighting with one another over their favorites.</p>
+
+      <h4>NYMPH NAMES</h4>
+      <p>Nymphs have names that sound beautiful and elemental.</p>
+      <p>
+        <span class="feature">Male Names:</span>Celano, Elion, Eratheis, Hyllis, Limnade, Linos, Myrmex, Olbia, Pega, Potameid, Pyron, Taygete<br/>
+        <span class="feature">Female Names:</span>Aegle, Alcyone, Arethusa, Asterope, Brettia, Brisa, Calybe, Crinae, Crimisa, Dodone, Electra, Erythia, Hesperia, Himalia, Oeneis, Laodice, Maia, Merope, Polydora, Rhene, Semestra
+      </p>
+      
+      <h4>NYMPH TRAITS</h4>
+      <p>Nymphs have the following traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Charisma score increases by 2, and your Wisdom score increases by 1.<br/>
+        <span class="feature">Age.</span>Nymphs are born cocooned within some feature of their associated element. For example, dryads are usually born within trees, and nereids may be born within giant clamshells. Young nymphs sleep in their cocoon for up to one hundred years before emerging, fully mature. They can live for as long as one thousand years, although many choose to return to the elements once their curiosity about the world has been satisfied.<br/>
+        <span class="feature">Alignment.</span>Nymphs tend toward chaotic alignments. They understand the concepts of good and evil, but they tend to select one or the other based on impulse rather than any deep-seated conviction. Nymphs tend to make a game out of performing acts that characterize their chosen alignment, rather than pausing for serious introspection.<br/>
+        <span class="feature">Size.</span>Nymphs are the same size as humans, but their builds typically reflect a life of leisure. Your size is Medium.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 30 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and Sylvan.<br/>
+        <span class="feature">Enthralling Beauty.</span>You possess unearthly grace and beauty, which allows you to dazzle and charm those who are susceptible to such things. You have proficiency in the Persuasion skill. Additionally, you can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short or long rest. Charisma is your spellcasting ability for this spell.<br/>
+        <span class="feature">Nymph Ancestry.</span>When you create your nymph, choose one of the following subraces: Aurae, Dryad, Naiad, Nereid, or Oread. You gain access to special traits and magic depending upon your ancestry.
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+
+    </setters>
+    <rules>
+      <stat name="charisma" value="2"/>
+      <stat name="wisdom" value="1"/>
+      <stat name="innate speed" value="30" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <grant type="Language" id="ID_LANGUAGE_SYLVAN" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_ENTHRALLING_BEAUTY" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NYMPH_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Enthralling Beauty" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_ENTHRALLING_BEAUTY">
+    <supports />
+    <description>
+      <p>You possess unearthly grace and beauty, which allows you to dazzle and charm those who are susceptible to such things. You have proficiency in the Persuasion skill. Additionally, you can cast the charm person spell once with this trait and regain the ability to do so when you finish a short or long rest. Charisma is your spellcasting ability for this spell.</p>
+    </description>
+    <sheet>
+      <description usage="1/Short Rest"><i>Charm Person</i>, DC {{enthralling beauty:dc}}</description>
+    </sheet>
+    <rules>
+      <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERSUASION" />
+      <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" level="1" />
+      <stat name="enthralling beauty:dc" value="8" />
+      <stat name="enthralling beauty:dc" value="proficiency" />
+      <stat name="enthralling beauty:dc" value="charisma:modifier" />
+    </rules>
+  </element>
+
+  <element name="Nymph Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NYMPH_ANCESTRY">
+    <description>
+      <p>When you create your nymph, choose one of the following subraces: Aurae, Dryad, Naiad, Nereid, or Oread. You gain access to special traits and magic depending upon your ancestry.</p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <select type="Sub Race" name="Nymph Ancestry" supports="Thylean Nymph" />
+    </rules>
+  </element>
+
+  <element name="Thylean Aurae Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_AURAE">
+    <supports>Thylean Nymph</supports>
+    <description>
+      <p>Aurae are associated with the breezes and the constellations of the night sky. They look like beautiful humans except that in dim lighting, their features are sometimes illuminated by cosmic light. Aurae are considered to be the wisest and most serious-minded nymphs, as they spend their time reflecting upon the eternal nature of the stars.</p>
+      <p>
+        <span class="feature">Aurae Ancestry.</span>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks when navigating by the stars. Starting at 3rd level, you can cast the <i>faerie fire</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>levitate</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_AURAE_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Aurae Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_AURAE_ANCESTRY">
+    <description>
+      <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks when navigating by the stars. Starting at 3rd level, you can cast the <i>faerie fire</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>levitate</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on Wisdom (Survival) checks when navigating by the stars.</description>
+      <description level="3">
+        You have advantage on Wisdom (Survival) checks when navigating by the stars.<br/>
+        1/short rest. <i>Faerie fire</i>. DC {{aurae ancestry:dc}}
+      </description>
+      <description level="7">
+        You have advantage on Wisdom (Survival) checks when navigating by the stars.<br/>
+        1/short rest. <i>Faerie fire</i>, and <i>Levitate</i>. DC {{aurae ancestry:dc}}
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Vision" id="ID_VISION_DARKVISION" />
+      <grant type="Spell" id="ID_PHB_SPELL_FAERIE_FIRE" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_LEVITATE" level="7" />
+      <stat name="aurae ancestry:dc" value="8" />
+      <stat name="aurae ancestry:dc" value="proficiency" />
+      <stat name="aurae ancestry:dc" value="charisma:modifier" />
+    </rules>
+  </element>
+
+  <element name="Thylean Dryad Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_DRYAD">
+    <supports>Thylean Nymph</supports>
+    <description>
+      <p>Dryads are associated with the forests and trees. They look like beautiful humans but with rough, bark-like skin that ranges in color from earthy browns and greens to flowery pinks and blues. Of all the nymphs, they have the most trouble adapting to civilization, as they do not cope well with being separated from their birth tree.</p>
+      <p>
+        <span class="feature">Dryad Ancestry.</span>You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions. Starting at 3rd level, you can cast the <i>goodberry</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>barkskin</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_DRYAD_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Dryad Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_DRYAD_ANCESTRY">
+    <description>
+      <p>
+        You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions. Starting at 3rd level, you can cast the <i>goodberry</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>barkskin</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet>
+      <description>You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.</description>
+      <description level="3">
+        You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.<br/>
+        1/short rest. <i>Goodberry</i>.
+      </description>
+      <description level="7">
+        You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.<br/>
+        1/short rest. <i>Goodberry</i>, and <i>Barkskin</i>.
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_GOODBERRY" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_BARKSKIN" level="7" />
+    </rules>
+  </element>
+
+  <element name="Thylean Naiad Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_NAIAD">
+    <supports>Thylean Nymph</supports>
+    <description>
+      <p>Naiads are associated with rivers, lakes, and rushing rapids. They look like beautiful humans but with long hair that coils and tumbles like a flowing waterfall from their shoulders. They adapt to civilization easily, as many mortal settlements are built along rivers. Any beautiful human that seems to enjoy bathing just a little too much might be accused of being a naiad.</p>
+      <p>
+        <span class="feature">Naiad Ancestry.</span>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>create or destroy water</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>control water</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NAIAD_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Naiad Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NAIAD_ANCESTRY">
+    <description>
+      <p>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>create or destroy water</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>control water</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
+    </description>
+    <sheet>
+      <description>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.</description>
+      <description level="3">
+        You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.<br/>
+        1/short rest. <i>Create or destroy water</i>.
+      </description>
+      <description level="7">
+        You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.<br/>
+        1/short rest. <i>Create or destroy water</i>, and <i>Control water</i>. DC {{naiad ancestry:dc}}
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_CREATE_OR_DESTROY_WATER" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_CONTROL_WATER" level="7" />
+      <stat name="naiad ancestry:dc" value="8" />
+      <stat name="naiad ancestry:dc" value="proficiency" />
+      <stat name="naiad ancestry:dc" value="charisma:modifier" />
+    </rules>
+  </element>
+
+  <element name="Thylean Nereid Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_NEREID">
+    <supports>Thylean Nymph</supports>
+    <description>
+      <p>Nereids are associated with the stormy seas and oceans. They look like beautiful humans but with pearlescent blue-green skin, luminous eyes, and webbed hands and feet. Nereids have no trouble adapting to civilization, but they are a rare sight, because they vastly prefer the ocean to walking on dry land.</p>
+      <p>
+        <span class="feature">Nereid Ancestry.</span>You can breathe underwater, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>fog cloud</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>water walk</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NEREID_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Nereid Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NEREID_ANCESTRY">
+    <description>
+      <p>You can breathe underwater, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>fog cloud</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>water walk</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
+    </description>
+    <sheet>
+      <description>You can breathe underwater, and you have a swimming speed of 40 ft.</description>
+      <description level="3">
+        You can breathe underwater, and you have a swimming speed of 40 ft.<br/>
+        1/short rest. <i>Fog cloud</i>.
+      </description>
+      <description level="7">
+        You can breathe underwater, and you have a swimming speed of 40 ft.<br/>
+        1/short rest. <i>Fog cloud</i>, and <i>Water walk</i>.
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_FOG_CLOUD" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_WATER_WALK" level="7" />
+    </rules>
+  </element>
+
+  <element name="Thylean Oread Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_OREAD">
+    <supports>Thylean Nymph</supports>
+    <description>
+      <p>Oreads are associated with rocky crags and the snowy peaks of mountains. They look like beautiful humans but with cat-shaped eyes. Oreads are fierce hunters, and they are known to stalk rural areas in search of interesting prey. Any hunter who can live for weeks in the wild and come away looking fresh as a flower might be an oread.</p>
+      <p>
+        <span class="feature">Oread Ancestry.</span>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions. Starting at 3rd level, you can cast the <i>hunter’s mark</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>misty step</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_OREAD_ANCESTRY" />
+    </rules>
+  </element>
+
+  <element name="Oread Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_OREAD_ANCESTRY">
+    <description>
+      <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions. Starting at 3rd level, you can cast the <i>hunter’s mark</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>misty step</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.</description>
+      <description level="3">
+        You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.<br/>
+        1/short rest. <i>Hunter's mark</i>.
+      </description>
+      <description level="7">
+        You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.<br/>
+        1/short rest. <i>Hunter's mark</i>, and <i>Misty step</i>.
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Vision" id="ID_VISION_DARKVISION" />
+      <grant type="Spell" id="ID_PHB_SPELL_HUNTERS_MARK" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_MISTY_STEP" level="7" />
+    </rules>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
@@ -7,31 +7,22 @@
 	</info>
   <element name="Thylean Nymph" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_NYMPH">
     <description>
-      <p class="flavor">
-        Nymphs are fey spirits that manifest from the beauty of the elemental forces of creation. There are many kinds of nymphs—dryads of the forests, naiads of the rivers, oreads of the mountains, aurae of the night sky, and nereids of the sea. They have walked the earth for millennia, ever since the Great Mother awakened them from the trees, waters, rocks, and breezes.
-      </p>
-      <p class="indent">
-        Nymphs are most at home in nature, but they have been known to disguise themselves and live amongst mortals, for they are desperately curious about the civilized world. In spite of this, they often have a difficult time comprehending the day-to-day struggle of civilized existence. Their charms are such that they may inadvertently seduce and domesticate mortal ‘pets’ who see to their every need, leaving them somewhat puzzled by the ugliness and hardship that seems to pervade cities.
-      </p>
-
+      <p class="flavor">Nymphs are fey spirits that manifest from the beauty of the elemental forces of creation. There are many kinds of nymphs—dryads of the forests, naiads of the rivers, oreads of the mountains, aurae of the night sky, and nereids of the sea. They have walked the earth for millennia, ever since the Great Mother awakened them from the trees, waters, rocks, and breezes.</p>
+      <p class="indent">Nymphs are most at home in nature, but they have been known to disguise themselves and live amongst mortals, for they are desperately curious about the civilized world. In spite of this, they often have a difficult time comprehending the day-to-day struggle of civilized existence. Their charms are such that they may inadvertently seduce and domesticate mortal ‘pets’ who see to their every need, leaving them somewhat puzzled by the ugliness and hardship that seems to pervade cities.</p>
       <h4>LEGEND OF THE NYMPHS</h4>
       <p>There was once a river running through the mountains. None can say which river or which mountains, for this was so long ago that the land has rolled and shifted so as to become unrecognizable in the time since. The mountains were blanketed in a soft powder of white snow, and as the snow melted, it crept along the ground and joined together into streams of water, which trickled along the rocks and formed a river. And the river coursed down through a forest, emptying into the ocean. So it went for eons.</p>
       <p class="indent">But then one day, the snow on the mountains had a thought. “Am I alike to the water in the streams?” And so also did the water in the river begin to wonder, “Am I alike to the roots of the trees?” They were curious, but it seemed that they would never know the answer, for just as the snow went to inspect the streams, it became the water, and just as the water went to inspect the trees, it became the roots. And so it went for eons.</p>
-      <p class="indent">Eventually, the Great Mother herself became aware of these questions. Holding the world in her embrace, she felt the curiosity of the elements rippling and vibrating across its surface, anxious for answers. And so, she loosened her grip—just slightly. The rippling thoughts of the snow and the waters and the rocks and the trees took shape, and their shapes were beautiful, for they were curiosity made manifest. These were the first nymphs.</p>
-      
+      <p class="indent">Eventually, the Great Mother herself became aware of these questions. Holding the world in her embrace, she felt the curiosity of the elements rippling and vibrating across its surface, anxious for answers. And so, she loosened her grip—just slightly. The rippling thoughts of the snow and the waters and the rocks and the trees took shape, and their shapes were beautiful, for they were curiosity made manifest. These were the first nymphs.</p>      
       <h4>BEAUTIFUL AND DIVERSE</h4>
       <p>Nymphs are famed for their feminine charms, but they are not exclusively female. Some are awakened from the elements with a mix of masculine and feminine features, and others are quintessential specimens of male splendor. As fey creatures, nymphs like little less than to be nailed down by the crude shackles of mortal language. They come in as many shapes and forms as the earth itself. The only physical trait that all of them have in common is an awe-inspiring beauty.</p>
-
       <h4>CURIOUS AND POSSESSIVE</h4>
       <p>Nymphs have an insatiable desire to learn as much as possible about both the natural and the civilized world. Because most have had eons to discover the splendor of nature, it is the civilized world that interests them the most. However, they are not usually very accustomed to mortal culture, and so they may think of men and women as interesting baubles to be collected and admired. Even civilized nymphs tend to cherish their friends and acquaintances as ‘pets’ to be manicured and proudly exhibited. They are not above bragging about their collection—or fighting with one another over their favorites.</p>
-
       <h4>NYMPH NAMES</h4>
       <p>Nymphs have names that sound beautiful and elemental.</p>
       <p>
         <span class="feature">Male Names:</span>Celano, Elion, Eratheis, Hyllis, Limnade, Linos, Myrmex, Olbia, Pega, Potameid, Pyron, Taygete<br/>
         <span class="feature">Female Names:</span>Aegle, Alcyone, Arethusa, Asterope, Brettia, Brisa, Calybe, Crinae, Crimisa, Dodone, Electra, Erythia, Hesperia, Himalia, Oeneis, Laodice, Maia, Merope, Polydora, Rhene, Semestra
-      </p>
-      
+      </p>      
       <h4>NYMPH TRAITS</h4>
       <p>Nymphs have the following traits.</p>
       <p>
@@ -72,7 +63,7 @@
     </sheet>
     <rules>
       <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERSUASION" />
-      <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" level="1" />
+      <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" />
       <stat name="enthralling beauty:dc" value="8" />
       <stat name="enthralling beauty:dc" value="proficiency" />
       <stat name="enthralling beauty:dc" value="charisma:modifier" />
@@ -98,7 +89,7 @@
         <span class="feature">Aurae Ancestry.</span>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks when navigating by the stars. Starting at 3rd level, you can cast the <i>faerie fire</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>levitate</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Aurae Nymph" display="false" />
     <rules>
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_AURAE_ANCESTRY" />
     </rules>
@@ -108,15 +99,11 @@
       <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks when navigating by the stars. Starting at 3rd level, you can cast the <i>faerie fire</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>levitate</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
     </description>
     <sheet>
-      <description>You have advantage on Wisdom (Survival) checks when navigating by the stars.</description>
-      <description level="3">
-        You have advantage on Wisdom (Survival) checks when navigating by the stars.<br/>
-        1/short rest. <i>Faerie fire</i>. DC {{aurae ancestry:dc}}
-      </description>
-      <description level="7">
-        You have advantage on Wisdom (Survival) checks when navigating by the stars.<br/>
-        1/short rest. <i>Faerie fire</i>, and <i>Levitate</i>. DC {{aurae ancestry:dc}}
-      </description>
+      <description>You have advantage on Survival checks when navigating by the stars.</description>
+      <description level="3">You have advantage on Survival checks when navigating by the stars.
+        1/short rest. <i>Faerie fire</i>. DC {{aurae ancestry:dc}}</description>
+      <description level="7">You have advantage on Survival checks when navigating by the stars.
+        1/short rest. <i>Faerie fire</i>, and <i>Levitate</i>. DC {{aurae ancestry:dc}}</description>
     </sheet>
     <rules>
       <grant type="Vision" id="ID_VISION_DARKVISION" />
@@ -136,7 +123,7 @@
         <span class="feature">Dryad Ancestry.</span>You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions. Starting at 3rd level, you can cast the <i>goodberry</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>barkskin</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Dryad Nymph" display="false" />
     <rules>
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_DRYAD_ANCESTRY" />
     </rules>
@@ -148,13 +135,13 @@
       </p>
     </description>
     <sheet>
-      <description>You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.</description>
+      <description>You are fluent in the languages of beasts and plants, and you have advantage on Survival checks in forested regions.</description>
       <description level="3">
-        You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.<br/>
+        You are fluent in the languages of beasts and plants, and you have advantage on Survival checks in forested regions.
         1/short rest. <i>Goodberry</i>.
       </description>
       <description level="7">
-        You are fluent in the languages of beasts and plants, and you have advantage on Wisdom (Survival) checks in forested regions.<br/>
+        You are fluent in the languages of beasts and plants, and you have advantage on Survival checks in forested regions.
         1/short rest. <i>Goodberry</i>, and <i>Barkskin</i>.
       </description>
     </sheet>
@@ -172,7 +159,7 @@
         <span class="feature">Naiad Ancestry.</span>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>create or destroy water</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>control water</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Naiad Nymph" display="false" />
     <rules>
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NAIAD_ANCESTRY" />
     </rules>
@@ -183,14 +170,10 @@
     </description>
     <sheet>
       <description>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.</description>
-      <description level="3">
-        You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.<br/>
-        1/short rest. <i>Create or destroy water</i>.
-      </description>
-      <description level="7">
-        You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.<br/>
-        1/short rest. <i>Create or destroy water</i>, and <i>Control water</i>. DC {{naiad ancestry:dc}}
-      </description>
+      <description level="3">You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.
+        1/short rest. <i>Create or destroy water</i>.</description>
+      <description level="7">You can hold your breath for 1 hour, and you have a swimming speed of 40 ft.
+        1/short rest. <i>Create or destroy water</i>, and <i>Control water</i>. DC {{naiad ancestry:dc}}</description>
     </sheet>
     <rules>
       <grant type="Spell" id="ID_PHB_SPELL_CREATE_OR_DESTROY_WATER" level="3" />
@@ -209,7 +192,7 @@
         <span class="feature">Nereid Ancestry.</span>You can breathe underwater, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>fog cloud</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>water walk</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Nereid Nymph" display="false" />
     <rules>
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NEREID_ANCESTRY" />
     </rules>
@@ -220,14 +203,10 @@
     </description>
     <sheet>
       <description>You can breathe underwater.</description>
-      <description level="3">
-        You can breathe underwater.<br/>
-        1/short rest. <i>Fog cloud</i>.
-      </description>
-      <description level="7">
-        You can breathe underwater.<br/>
-        1/short rest. <i>Fog cloud</i>, and <i>Water walk</i>.
-      </description>
+      <description level="3">You can breathe underwater.
+        1/short rest. <i>Fog cloud</i>.</description>
+      <description level="7">You can breathe underwater.
+        1/short rest. <i>Fog cloud</i>, and <i>Water walk</i>.</description>
     </sheet>
     <rules>
       <stat name="innate speed:swim" value="40" />
@@ -244,7 +223,7 @@
         <span class="feature">Oread Ancestry.</span>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions. Starting at 3rd level, you can cast the <i>hunter’s mark</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>misty step</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Oread Nymph" display="false" />
     <rules>
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_OREAD_ANCESTRY" />
     </rules>
@@ -254,15 +233,11 @@
       <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions. Starting at 3rd level, you can cast the <i>hunter’s mark</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>misty step</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
     </description>
     <sheet>
-      <description>You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.</description>
-      <description level="3">
-        You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.<br/>
-        1/short rest. <i>Hunter's mark</i>.
-      </description>
-      <description level="7">
-        You have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions.<br/>
-        1/short rest. <i>Hunter's mark</i>, and <i>Misty step</i>.
-      </description>
+      <description>You have advantage on Survival checks in steppes, rocky islands, and mountainous regions.</description>
+      <description level="3">You have advantage on Survival checks in steppes, rocky islands, and mountainous regions.
+        1/short rest. <i>Hunter's mark</i>.</description>
+      <description level="7">You have advantage on Survival checks in steppes, rocky islands, and mountainous regions.
+        1/short rest. <i>Hunter's mark</i>, and <i>Misty step</i>.</description>
     </sheet>
     <rules>
       <grant type="Vision" id="ID_VISION_DARKVISION" />

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleannymph.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Nymph" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_NYMPH">
-    <supports />
     <description>
       <p class="flavor">
         Nymphs are fey spirits that manifest from the beauty of the elemental forces of creation. There are many kinds of nymphs—dryads of the forests, naiads of the rivers, oreads of the mountains, aurae of the night sky, and nereids of the sea. They have walked the earth for millennia, ever since the Great Mother awakened them from the trees, waters, rocks, and breezes.
@@ -64,7 +63,6 @@
   </element>
 
   <element name="Enthralling Beauty" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_ENTHRALLING_BEAUTY">
-    <supports />
     <description>
       <p>You possess unearthly grace and beauty, which allows you to dazzle and charm those who are susceptible to such things. You have proficiency in the Persuasion skill. Additionally, you can cast the charm person spell once with this trait and regain the ability to do so when you finish a short or long rest. Charisma is your spellcasting ability for this spell.</p>
     </description>
@@ -86,12 +84,13 @@
     </description>
     <sheet display="false" />
     <rules>
-      <select type="Sub Race" name="Nymph Ancestry" supports="Thylean Nymph" />
+      <select type="Sub Race" name="Nymph Ancestry" supports="Thylean Nymph Ancestry" />
     </rules>
   </element>
 
+  <!-- subraces -->
   <element name="Thylean Aurae Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_AURAE">
-    <supports>Thylean Nymph</supports>
+    <supports>Thylean Nymph Ancestry</supports>
     <description>
       <p>Aurae are associated with the breezes and the constellations of the night sky. They look like beautiful humans except that in dim lighting, their features are sometimes illuminated by cosmic light. Aurae are considered to be the wisest and most serious-minded nymphs, as they spend their time reflecting upon the eternal nature of the stars.</p>
       <p>
@@ -103,7 +102,6 @@
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_AURAE_ANCESTRY" />
     </rules>
   </element>
-
   <element name="Aurae Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_AURAE_ANCESTRY">
     <description>
       <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks when navigating by the stars. Starting at 3rd level, you can cast the <i>faerie fire</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>levitate</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
@@ -130,7 +128,7 @@
   </element>
 
   <element name="Thylean Dryad Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_DRYAD">
-    <supports>Thylean Nymph</supports>
+    <supports>Thylean Nymph Ancestry</supports>
     <description>
       <p>Dryads are associated with the forests and trees. They look like beautiful humans but with rough, bark-like skin that ranges in color from earthy browns and greens to flowery pinks and blues. Of all the nymphs, they have the most trouble adapting to civilization, as they do not cope well with being separated from their birth tree.</p>
       <p>
@@ -142,7 +140,6 @@
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_DRYAD_ANCESTRY" />
     </rules>
   </element>
-
   <element name="Dryad Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_DRYAD_ANCESTRY">
     <description>
       <p>
@@ -167,7 +164,7 @@
   </element>
 
   <element name="Thylean Naiad Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_NAIAD">
-    <supports>Thylean Nymph</supports>
+    <supports>Thylean Nymph Ancestry</supports>
     <description>
       <p>Naiads are associated with rivers, lakes, and rushing rapids. They look like beautiful humans but with long hair that coils and tumbles like a flowing waterfall from their shoulders. They adapt to civilization easily, as many mortal settlements are built along rivers. Any beautiful human that seems to enjoy bathing just a little too much might be accused of being a naiad.</p>
       <p>
@@ -179,7 +176,6 @@
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NAIAD_ANCESTRY" />
     </rules>
   </element>
-
   <element name="Naiad Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NAIAD_ANCESTRY">
     <description>
       <p>You can hold your breath for 1 hour, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>create or destroy water</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>control water</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
@@ -205,7 +201,7 @@
   </element>
 
   <element name="Thylean Nereid Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_NEREID">
-    <supports>Thylean Nymph</supports>
+    <supports>Thylean Nymph Ancestry</supports>
     <description>
       <p>Nereids are associated with the stormy seas and oceans. They look like beautiful humans but with pearlescent blue-green skin, luminous eyes, and webbed hands and feet. Nereids have no trouble adapting to civilization, but they are a rare sight, because they vastly prefer the ocean to walking on dry land.</p>
       <p>
@@ -217,7 +213,6 @@
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NEREID_ANCESTRY" />
     </rules>
   </element>
-
   <element name="Nereid Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_NEREID_ANCESTRY">
     <description>
       <p>You can breathe underwater, and you have a swimming speed of 40 ft. Starting at 3rd level, you may cast the <i>fog cloud</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>water walk</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>
@@ -240,7 +235,7 @@
   </element>
 
   <element name="Thylean Oread Nymph" type="Sub Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SUB_RACE_THYLEAN_NYMPH_OREAD">
-    <supports>Thylean Nymph</supports>
+    <supports>Thylean Nymph Ancestry</supports>
     <description>
       <p>Oreads are associated with rocky crags and the snowy peaks of mountains. They look like beautiful humans but with cat-shaped eyes. Oreads are fierce hunters, and they are known to stalk rural areas in search of interesting prey. Any hunter who can live for weeks in the wild and come away looking fresh as a flower might be an oread.</p>
       <p>
@@ -252,7 +247,6 @@
       <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_OREAD_ANCESTRY" />
     </rules>
   </element>
-
   <element name="Oread Ancestry" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_NYMPH_OREAD_ANCESTRY">
     <description>
       <p>You have Darkvision out to 60 ft., and you have advantage on Wisdom (Survival) checks in steppes, rocky islands, and mountainous regions. Starting at 3rd level, you can cast the <i>hunter’s mark</i> spell once with this trait and regain the ability to do so after a short or long rest. Starting at 7th level, you can cast the <i>misty step</i> spell once with this trait and regain the ability to do so after a short or long rest. Charisma is your spellcasting ability for these spells.</p>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
@@ -10,28 +10,22 @@
       <p class="flavor">
         Satyrs are a race of fey creatures with a strong link to the Feywild and all of the creatures and races that come from that place. They prefer forested wilderness but are not afraid to enter towns and cities to enjoy the company and other benefits of civilization.
       </p>
-
       <h4>GOAT MEN</h4>
       <p>Satyrs have the lower body of a goat and the upper body of an elf. A pair of goat-like horns sprout from their foreheads. These horns can range from small spikes to huge horns worthy of a mountain goat. In addition to a full head of hair, satyrs grow fur on their arms, legs, and torsos. Some satyrs grow less fur, and many choose to carefully shave the hair from their arms and body. They can have brown, black, blonde, red, grey, or white hair. Their skin color ranges from dark to pale.</p>
-      
       <h4>HEDONISTIC</h4>
       <p>Satyrs are in tune with their emotions to a degree that can be disturbing to other races. They want to experience everything: happiness, sadness, love, rage, etc. The only thing they avoid is boredom.</p>
       <p class="indent">They love music, wine, and dancing. They also enjoy an interest in carnal pleasures, and they are not afraid to share a bed with any of the other intelligent races.</p>
-
       <h4>MUSIC LOVERS</h4>
       <p>Satyrs love to listen to music. They will happily spend long stretches of time both playing and composing new music. They are known to travel great distances to hear new songs, instruments, and poetry.</p>
-
       <h4>SATYRS IN THYLEA</h4>
       <p>Satyrs don’t have the same strained relationship with the civilized races of Thylea that the centaurs do. Satyrs can be found in many towns and villages throughout Thylea, as well as the great city of Mytros. They are attracted to the abundance of experiences that civilization provides: the food, the wine, and most especially the music.</p>
       <p class="indent">The civilized races of Thylea are suspicious of satyrs, for there are many stories of satyrs seducing and corrupting both the old and the young alike.</p>
-      
       <h4>SATYR NAMES</h4>
       <p>Satyrs have names that they draw from legends and myths—and from the powers that rule over the Feywild.</p>
       <p>
         <span class="feature">Male Names:</span>Adrastos, Aeolus, Brontes, Castor, Cephalus, Glaucus, Helios, Iacchus, Kreios, Lycus, Melanthios, Okeanos, and Proteus.<br/>
         <span class="feature">Female Names:</span>Acantha, Astraea, Briseis, Clio, Erato, Harmonia, Ianthe, Jocasta, Melete, Phaedra, Phoebe, Selene, and Tethys.
       </p>
-
       <h4>SATYR TRAITS</h4>
       <p>Satyrs have the following traits.</p>
       <p>
@@ -46,7 +40,7 @@
         <span  class="feature">Enchanting Music.</span>You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Satyr" display="false" />
     <setters>
       <set name="names" type="male">Adrastos, Aeolus, Brontes, Castor, Cephalus, Glaucus, Helios, Iacchus, Kreios, Lycus, Melanthios, Okeanos, Proteus</set>
       <set name="names" type="female">Acantha, Astraea, Briseis, Clio, Erato, Harmonia, Ianthe, Jocasta, Melete, Phaedra, Phoebe, Selene, Tethys</set>
@@ -81,7 +75,7 @@
       <p>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.</p>
     </description>
     <sheet>
-      <description>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.</description>
+      <description>You have advantage on Performance checks made with the selected instrument of your choice. You can also memorize and perform any song after hearing it only once.</description>
     </sheet>
     <rules>
       <select type="Proficiency" name="Musical Instrument (Satyr)" supports="Musical Instrument" number="1" />
@@ -90,24 +84,12 @@
 
   <element name="Enchanting Music" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_ENCHANTING_MUSIC">
     <description>
-      You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+      <p>You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.</p>
     </description>
     <sheet>
-      <description>
-        <p>
-          You can cast the <i>minor illusion</i> cantrip. Casting this spell requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
-        </p>
-      </description>
-      <description level="3">
-        <p>
-          You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
-        </p>
-      </description>
-      <description level="5">
-        <p>
-          You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. You can also cast the <i>suggestion</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
-        </p>
-      </description>
+      <description>You can cast the <i>minor illusion</i> cantrip. Casting this spell requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.</description>
+      <description level="3">You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.</description>
+      <description level="5">You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. You can also cast the <i>suggestion</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.</description>
     </sheet>
     <rules>
       <grant type="Spell" id="ID_PHB_SPELL_MINOR_ILLUSION" />

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Satyr" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_SATYR">
-    <supports />
     <description>
       <p class="flavor">
         Satyrs are a race of fey creatures with a strong link to the Feywild and all of the creatures and races that come from that place. They prefer forested wilderness but are not afraid to enter towns and cities to enjoy the company and other benefits of civilization.
@@ -66,18 +65,15 @@
   </element>
 
   <element name="Fey Heritage" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_FEY_HERITAGE">
-    <supports />
     <description>
       <p>You have advantage on saving throws against being charmed or frightened, and spells can’t put you to sleep.</p>
     </description>
     <sheet>
       <description>You have advantage on saving throws against being charmed or frightened, and spells can’t put you to sleep.</description>
     </sheet>
-    <rules/>
   </element>
 
   <element name="Memory for Music" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_MEMORY_FOR_MUSIC">
-    <supports />
     <description>
       <p>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.</p>
     </description>
@@ -90,7 +86,6 @@
   </element>
 
   <element name="Enchanting Music" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_ENCHANTING_MUSIC">
-    <supports />
     <description>
       You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
     </description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleansatyr.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml" />
+		</update>
+	</info>
+  <element name="Thylean Satyr" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_SATYR">
+    <supports />
+    <description>
+      <p class="flavor">
+        Satyrs are a race of fey creatures with a strong link to the Feywild and all of the creatures and races that come from that place. They prefer forested wilderness but are not afraid to enter towns and cities to enjoy the company and other benefits of civilization.
+      </p>
+
+      <h4>GOAT MEN</h4>
+      <p>Satyrs have the lower body of a goat and the upper body of an elf. A pair of goat-like horns sprout from their foreheads. These horns can range from small spikes to huge horns worthy of a mountain goat. In addition to a full head of hair, satyrs grow fur on their arms, legs, and torsos. Some satyrs grow less fur, and many choose to carefully shave the hair from their arms and body. They can have brown, black, blonde, red, grey, or white hair. Their skin color ranges from dark to pale.</p>
+      
+      <h4>HEDONISTIC</h4>
+      <p>Satyrs are in tune with their emotions to a degree that can be disturbing to other races. They want to experience everything: happiness, sadness, love, rage, etc. The only thing they avoid is boredom.</p>
+      <p class="indent">They love music, wine, and dancing. They also enjoy an interest in carnal pleasures, and they are not afraid to share a bed with any of the other intelligent races.</p>
+
+      <h4>MUSIC LOVERS</h4>
+      <p>Satyrs love to listen to music. They will happily spend long stretches of time both playing and composing new music. They are known to travel great distances to hear new songs, instruments, and poetry.</p>
+
+      <h4>SATYRS IN THYLEA</h4>
+      <p>Satyrs don’t have the same strained relationship with the civilized races of Thylea that the centaurs do. Satyrs can be found in many towns and villages throughout Thylea, as well as the great city of Mytros. They are attracted to the abundance of experiences that civilization provides: the food, the wine, and most especially the music.</p>
+      <p class="indent">The civilized races of Thylea are suspicious of satyrs, for there are many stories of satyrs seducing and corrupting both the old and the young alike.</p>
+      
+      <h4>SATYR NAMES</h4>
+      <p>Satyrs have names that they draw from legends and myths—and from the powers that rule over the Feywild.</p>
+      <p>
+        <span class="feature">Male Names:</span>Adrastos, Aeolus, Brontes, Castor, Cephalus, Glaucus, Helios, Iacchus, Kreios, Lycus, Melanthios, Okeanos, and Proteus.<br/>
+        <span class="feature">Female Names:</span>Acantha, Astraea, Briseis, Clio, Erato, Harmonia, Ianthe, Jocasta, Melete, Phaedra, Phoebe, Selene, and Tethys.
+      </p>
+
+      <h4>SATYR TRAITS</h4>
+      <p>Satyrs have the following traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Dexterity score increases by 2, and your Charisma score increases by 1.<br/>
+        <span class="feature">Age.</span>Satyrs mature quickly, reaching adulthood by their early teens. They can live for several centuries.<br/>
+        <span class="feature">Alignment.</span>Most satyrs are chaotic neutral. They live for pleasure, sensual experience, and excitement. There are some satyrs who have developed empathy for others and tend toward good. Other satyrs have grown cruel and enjoy causing painful emotions.<br/>
+        <span class="feature">Size.</span>Satyrs range from 4 to 5 feet in height. They weigh between 100 and 150 pounds. Your size is Medium.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 30 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and Sylvan.<br/>
+        <span class="feature">Fey Heritage.</span>You have advantage on saving throws against being charmed or frightened, and spells can’t put you to sleep.<br/>
+        <span class="feature">Memory for Music.</span>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.<br/>
+        <span  class="feature">Enchanting Music.</span>You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+
+    </setters>
+    <rules>
+      <stat name="dexterity" value="2"/>
+      <stat name="charisma" value="1"/>
+      <stat name="innate speed" value="30" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <grant type="Language" id="ID_LANGUAGE_SYLVAN" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_FEY_HERITAGE" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_MEMORY_FOR_MUSIC" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_ENCHANTING_MUSIC" />
+    </rules>
+  </element>
+
+  <element name="Fey Heritage" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_FEY_HERITAGE">
+    <supports />
+    <description>
+      <p>You have advantage on saving throws against being charmed or frightened, and spells can’t put you to sleep.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on saving throws against being charmed or frightened, and spells can’t put you to sleep.</description>
+    </sheet>
+    <rules/>
+  </element>
+
+  <element name="Memory for Music" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_MEMORY_FOR_MUSIC">
+    <supports />
+    <description>
+      <p>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.</p>
+    </description>
+    <sheet>
+      <description>You have proficiency with one instrument of your choice. You have advantage on Performance checks made with the selected instrument. You can also memorize and perform any song after hearing it only once.</description>
+    </sheet>
+    <rules>
+      <select type="Proficiency" name="Musical Instrument (Satyr)" supports="Musical Instrument" number="1" />
+    </rules>
+  </element>
+
+  <element name="Enchanting Music" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SATYR_ENCHANTING_MUSIC">
+    <supports />
+    <description>
+      You can cast the <i>minor illusion</i> cantrip. When you reach 3rd level, you can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can also cast the <i>suggestion</i> spell with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+    </description>
+    <sheet>
+      <description>
+        <p>
+          You can cast the <i>minor illusion</i> cantrip. Casting this spell requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+        </p>
+      </description>
+      <description level="3">
+        <p>
+          You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+        </p>
+      </description>
+      <description level="5">
+        <p>
+          You can cast the <i>minor illusion</i> cantrip. You can cast the <i>sleep</i> spell once with this trait and regain the ability to do so when you finish a long rest. You can also cast the <i>suggestion</i> spell once with this trait and regain the ability to do so when you finish a long rest. Casting these spells requires access to an instrument that you are proficient with. Charisma is your spellcasting ability for these spells.
+        </p>
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_MINOR_ILLUSION" />
+      <grant type="Spell" id="ID_PHB_SPELL_SLEEP" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_SUGGESTION" level="5" />
+    </rules>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleansatyr.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansatyr.xml" />
 		</update>
@@ -49,7 +48,11 @@
     </description>
     <sheet display="false" />
     <setters>
-
+      <set name="names" type="male">Adrastos, Aeolus, Brontes, Castor, Cephalus, Glaucus, Helios, Iacchus, Kreios, Lycus, Melanthios, Okeanos, Proteus</set>
+      <set name="names" type="female">Acantha, Astraea, Briseis, Clio, Erato, Harmonia, Ianthe, Jocasta, Melete, Phaedra, Phoebe, Selene, Tethys</set>
+      <set name="names-format">{{name}}</set>
+      <set name="height">4'10"</set>
+      <set name="weight">120 lbs.</set>
     </setters>
     <rules>
       <stat name="dexterity" value="2"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
@@ -7,7 +7,6 @@
 		</update>
 	</info>
   <element name="Thylean Siren" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_SIREN">
-    <supports />
     <description>
       <p class="flavor">
         Sirens are a race of winged, aquatic humanoids that typically dwell near rocky sea cliffs. They are famed for their beautiful voices, which they use to sing haunting lamentations, captivating listeners and transporting them to a bygone age. Sirens are rarely found very far inland. They prefer to remain near the coasts, as the gentle roar of the ocean waves calms their roiling emotions.
@@ -72,40 +71,33 @@
   </element>
 
   <element name="Enthralling Voice" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_ENTHRALLING_VOICE">
-    <supports />
     <description>
       <p>You have advantage on Performance and Persuasion checks made with your voice. Additionally, your powerful lungs allow you to hold your breath for up to 1 hour.</p>
     </description>
     <sheet>
       <description>You have advantage on Performance and Persuasion checks made with your voice. Additionally, your powerful lungs allow you to hold your breath for up to 1 hour.</description>
     </sheet>
-    <rules/>
   </element>
 
   <element name="Wavering Emotions" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_WAVERING_EMOTIONS">
-    <supports />
     <description>
       <p>Your mood affects your ability to sing and fly. After any short or long rest, you must choose whether you are feeling joyful or sad. While you are feeling sad, you lose your flying speed but gain <i>songs of sorrow</i>. While you are feeling joyful, you gain your flying speed but lose <i>songs of sorrow</i>. Your mood may change before the next time you rest, but it won’t affect which ability you have access to until after your next rest is completed.</p>
     </description>
     <sheet>
       <description>Your mood affects your ability to sing and fly. After any short or long rest, you must choose whether you are feeling joyful or sad. While you are feeling sad, you lose your flying speed but gain <i>songs of sorrow</i>. While you are feeling joyful, you gain your flying speed but lose <i>songs of sorrow</i>. Your mood may change before the next time you rest, but it won’t affect which ability you have access to until after your next rest is completed.</description>
     </sheet>
-    <rules/>
   </element>
 
   <element name="Flight" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_FLIGHT">
-    <supports />
     <description>
       <p>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</p>
     </description>
     <sheet>
       <description>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</description>
     </sheet>
-    <rules/>
   </element>
 
   <element name="Songs of Sorrow" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_SONGS_OF_SORROW">
-    <supports />
     <description>
       <p>Your lamentations have a powerful effect on anyone who can hear them. You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 3rd level, you can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 5th level, you can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.</p>
     </description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
@@ -7,35 +7,25 @@
 	</info>
   <element name="Thylean Siren" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_SIREN">
     <description>
-      <p class="flavor">
-        Sirens are a race of winged, aquatic humanoids that typically dwell near rocky sea cliffs. They are famed for their beautiful voices, which they use to sing haunting lamentations, captivating listeners and transporting them to a bygone age. Sirens are rarely found very far inland. They prefer to remain near the coasts, as the gentle roar of the ocean waves calms their roiling emotions.
-      </p>
-      <p class="flavor">
-        Sirens typically experience fluctuating moods from one day to the next, ranging from extreme joy and hope for the future, to extreme sorrow and pessimism. No matter how a siren feels, she expresses her emotion through song. On good days, she may annoy her companions with chirpy melodies and vocal warm-ups as she glides around on outstretched wings. Bad days, on the other hand, may see her moaning and wailing and dragging her feet.
-      </p>
-
+      <p class="flavor">Sirens are a race of winged, aquatic humanoids that typically dwell near rocky sea cliffs. They are famed for their beautiful voices, which they use to sing haunting lamentations, captivating listeners and transporting them to a bygone age. Sirens are rarely found very far inland. They prefer to remain near the coasts, as the gentle roar of the ocean waves calms their roiling emotions.</p>
+      <p class="flavor">Sirens typically experience fluctuating moods from one day to the next, ranging from extreme joy and hope for the future, to extreme sorrow and pessimism. No matter how a siren feels, she expresses her emotion through song. On good days, she may annoy her companions with chirpy melodies and vocal warm-ups as she glides around on outstretched wings. Bad days, on the other hand, may see her moaning and wailing and dragging her feet.</p>
       <h4>LEGEND OF THE SIRENS</h4>
       <p>The sirens once lived on a great expanse of shoals in the Cerulean Gulf, where they built a city of brilliant white limestone. Its towering spires and pillars thrust out from the rocky waters, allowing the sirens to fly or swim as they pleased. They lived here in joy, singing praises to Sydon, who governed the oceans. Sydon heard this from his throne in Praxys and scowled. “Were they truly grateful, they would not build their towers to rival mine.”</p>
       <p class="indent">When the sirens learned that Sydon was displeased, they were heartbroken. They dismantled their towers and composed new melodies—songs of repentance—which once more carried on the winds to the ears of the Titan. He was unmoved. “Were they truly repentant, they would not sing so brazenly, but they would go meekly and offer the proper sacrifices in place of songs.”</p>
       <p class="indent">This time, the sirens were utterly stricken. They had believed that their songs were cherished by the gods. Their voices were stilled, and in the ensuing silence, the brilliance of the city faded into shadow. Stone foundations cracked, and pediments grew heavy. The pillars collapsed, and the city of the sirens sank deep into the ocean, swallowed by churning waters. Even its name was forgotten.</p>
       <p class="indent">Centuries passed in silence. Eventually, a new song began—an endless lamentation for the city that now sleeps on the ocean floor. When Lutheria learned that the city of the sirens had been destroyed, she laughed. She captured an entire flock of the pitiful creatures and gleefully cursed them, twisting them into something monstrous. These were the first harpies.</p>
-      
       <h4>OCEAN LOVERS</h4>
       <p>Sirens are not amphibious, but they are well-adapted for living in and around water. They are thought to descend from an ancient Nereid who fell in love with an avian celestial. Iridescent scales cover many parts of their body, and their taloned hands and feet are excellent for fishing. They live in small flocks along the shores of the ocean. Siren artwork, poetry, and architecture emphasize their special relationship with both the clouds above and the sea below.</p>
-
       <h4>MOURNFUL SINGERS</h4>
       <p>Every siren is born with an abiding sense of sorrow that never fades—a soul-crushing grief caused by the loss of her ancestral home. From an early age, sirens learn to sing the ancient songs of their lost city, which evoke heart-wrenching memories of a time that will never come again. Anyone who hears a siren’s song is immediately mesmerized by the overwhelming emotion conveyed by her beautiful voice. Some are moved to tears—others collapse into catatonia. The siren herself is not exempt from this—the moment she hears her own lamentations, she experiences an intense pang of loss.</p>
-
       <h4>WINGED MESSENGERS</h4>
       <p>Sirens have broad, feathered wings growing out of their backs, which allow them to fly like birds. For this reason, sirens are often employed as messengers, tasked with conveying satchels of written letters from one city to another. However, a siren can only fly when her heart is filled with light. On such days, her songs are bright and joyful, no matter what manner of message she carries. Thus the saying, “A siren in good spirits may yet carry ill news.”</p>
-
       <h4>SIREN NAMES</h4>
       <p>Sirens have names that sound lyrical and sad. They are ancient names, carried down from generation to generation, and each is associated with an ancestral song. Sirens choose their own names when they come of age, selecting one from the song that moves them most deeply.</p>
       <p>
         <span class="feature">Male Names:</span>Alovar, Celeus, Everean, Gaiar, Helean, Inareus, Leiro, Meiar, Nerean, Oren, Reilan, Taeren<br/>
         <span class="feature">Female Names:</span>Alovarea, Celea, Everea, Gaia, Helena, Inarea, Leira, Meia, Nerea, Orena, Reilana, Taerena
       </p>
-
       <h4>SIREN TRAITS</h4>
       <p>Sirens have the following traits.</p>
       <p>
@@ -51,7 +41,7 @@
         <span class="feature">Songs of Sorrow.</span>Your lamentations have a powerful effect on anyone who can hear them. You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 3rd level, you can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 5th level, you can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
       </p>
     </description>
-    <sheet display="false" />
+    <sheet alt="Siren" display="false" />
     <setters>
       <set name="names" type="male">Alovar, Celeus, Everean, Gaiar, Helean, Inareus, Leiro, Meiar, Nerean, Oren, Reilan, Taeren</set>
       <set name="names" type="female">Alovarea, Celea, Everea, Gaia, Helena, Inarea, Leira, Meia, Nerea, Orena, Reilana, Taerena</set>
@@ -106,15 +96,9 @@
       <p>Your lamentations have a powerful effect on anyone who can hear them. You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 3rd level, you can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 5th level, you can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.</p>
     </description>
     <sheet>
-      <description>
-        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for this spell, and the targets of your spell must have the ability to hear you singing.
-      </description>
-      <description level="3">
-        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
-      </description>
-      <description level="5">
-        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
-      </description>
+      <description>You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for this spell, and the targets of your spell must have the ability to hear you singing.</description>
+      <description level="3">You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.</description>
+      <description level="5">You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.</description>
     </sheet>
     <rules>
       <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" />

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="race-thyleansiren.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml" />
 		</update>
@@ -54,7 +53,9 @@
     </description>
     <sheet display="false" />
     <setters>
-
+      <set name="names" type="male">Alovar, Celeus, Everean, Gaiar, Helean, Inareus, Leiro, Meiar, Nerean, Oren, Reilan, Taeren</set>
+      <set name="names" type="female">Alovarea, Celea, Everea, Gaia, Helena, Inarea, Leira, Meia, Nerea, Orena, Reilana, Taerena</set>
+      <set name="names-format">{{name}}</set>
     </setters>
     <rules>
       <stat name="dexterity" value="1"/>
@@ -92,9 +93,12 @@
     <description>
       <p>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</p>
     </description>
-    <sheet>
+    <sheet display="false">
       <description>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</description>
     </sheet>
+    <rules>
+      <stat name="innate speed:fly" value="30" bonus="base" equipped="![armor:medium],![armor:heavy]" />
+    </rules>
   </element>
 
   <element name="Songs of Sorrow" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_SONGS_OF_SORROW">

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="race-thyleansiren.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/race-thyleansiren.xml" />
+		</update>
+	</info>
+  <element name="Thylean Siren" type="Race" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACE_THYLEAN_SIREN">
+    <supports />
+    <description>
+      <p class="flavor">
+        Sirens are a race of winged, aquatic humanoids that typically dwell near rocky sea cliffs. They are famed for their beautiful voices, which they use to sing haunting lamentations, captivating listeners and transporting them to a bygone age. Sirens are rarely found very far inland. They prefer to remain near the coasts, as the gentle roar of the ocean waves calms their roiling emotions.
+      </p>
+      <p class="flavor">
+        Sirens typically experience fluctuating moods from one day to the next, ranging from extreme joy and hope for the future, to extreme sorrow and pessimism. No matter how a siren feels, she expresses her emotion through song. On good days, she may annoy her companions with chirpy melodies and vocal warm-ups as she glides around on outstretched wings. Bad days, on the other hand, may see her moaning and wailing and dragging her feet.
+      </p>
+
+      <h4>LEGEND OF THE SIRENS</h4>
+      <p>The sirens once lived on a great expanse of shoals in the Cerulean Gulf, where they built a city of brilliant white limestone. Its towering spires and pillars thrust out from the rocky waters, allowing the sirens to fly or swim as they pleased. They lived here in joy, singing praises to Sydon, who governed the oceans. Sydon heard this from his throne in Praxys and scowled. “Were they truly grateful, they would not build their towers to rival mine.”</p>
+      <p class="indent">When the sirens learned that Sydon was displeased, they were heartbroken. They dismantled their towers and composed new melodies—songs of repentance—which once more carried on the winds to the ears of the Titan. He was unmoved. “Were they truly repentant, they would not sing so brazenly, but they would go meekly and offer the proper sacrifices in place of songs.”</p>
+      <p class="indent">This time, the sirens were utterly stricken. They had believed that their songs were cherished by the gods. Their voices were stilled, and in the ensuing silence, the brilliance of the city faded into shadow. Stone foundations cracked, and pediments grew heavy. The pillars collapsed, and the city of the sirens sank deep into the ocean, swallowed by churning waters. Even its name was forgotten.</p>
+      <p class="indent">Centuries passed in silence. Eventually, a new song began—an endless lamentation for the city that now sleeps on the ocean floor. When Lutheria learned that the city of the sirens had been destroyed, she laughed. She captured an entire flock of the pitiful creatures and gleefully cursed them, twisting them into something monstrous. These were the first harpies.</p>
+      
+      <h4>OCEAN LOVERS</h4>
+      <p>Sirens are not amphibious, but they are well-adapted for living in and around water. They are thought to descend from an ancient Nereid who fell in love with an avian celestial. Iridescent scales cover many parts of their body, and their taloned hands and feet are excellent for fishing. They live in small flocks along the shores of the ocean. Siren artwork, poetry, and architecture emphasize their special relationship with both the clouds above and the sea below.</p>
+
+      <h4>MOURNFUL SINGERS</h4>
+      <p>Every siren is born with an abiding sense of sorrow that never fades—a soul-crushing grief caused by the loss of her ancestral home. From an early age, sirens learn to sing the ancient songs of their lost city, which evoke heart-wrenching memories of a time that will never come again. Anyone who hears a siren’s song is immediately mesmerized by the overwhelming emotion conveyed by her beautiful voice. Some are moved to tears—others collapse into catatonia. The siren herself is not exempt from this—the moment she hears her own lamentations, she experiences an intense pang of loss.</p>
+
+      <h4>WINGED MESSENGERS</h4>
+      <p>Sirens have broad, feathered wings growing out of their backs, which allow them to fly like birds. For this reason, sirens are often employed as messengers, tasked with conveying satchels of written letters from one city to another. However, a siren can only fly when her heart is filled with light. On such days, her songs are bright and joyful, no matter what manner of message she carries. Thus the saying, “A siren in good spirits may yet carry ill news.”</p>
+
+      <h4>SIREN NAMES</h4>
+      <p>Sirens have names that sound lyrical and sad. They are ancient names, carried down from generation to generation, and each is associated with an ancestral song. Sirens choose their own names when they come of age, selecting one from the song that moves them most deeply.</p>
+      <p>
+        <span class="feature">Male Names:</span>Alovar, Celeus, Everean, Gaiar, Helean, Inareus, Leiro, Meiar, Nerean, Oren, Reilan, Taeren<br/>
+        <span class="feature">Female Names:</span>Alovarea, Celea, Everea, Gaia, Helena, Inarea, Leira, Meia, Nerea, Orena, Reilana, Taerena
+      </p>
+
+      <h4>SIREN TRAITS</h4>
+      <p>Sirens have the following traits.</p>
+      <p>
+        <span class="feature">Ability Score Increase.</span>Your Charisma score increases by 2, and your Dexterity score increases by 1.<br/>
+        <span class="feature">Age.</span>Sirens mature at the same rate as humans, but they live about five times as long.<br/>
+        <span class="feature">Alignment.</span>From birth, sirens experience deep feelings of sorrow from the loss of their ancestral home. Some wish to prevent another such tragedy from befalling other races, which draws them toward good alignments. Others become bitter and pessimistic, tending toward neutral alignments.<br/>
+        <span class="feature">Size.</span>Sirens are slightly shorter than humans, and they have a wingspan of about 6 feet. Your size is Medium.<br/>
+        <span class="feature">Speed.</span>Your base walking speed is 30 feet.<br/>
+        <span class="feature">Language.</span>You can speak, read, and write Common and Celestial.<br/>
+        <span class="feature">Enthralling Voice.</span>You have advantage on Performance and Persuasion checks made with your voice. Additionally, your powerful lungs allow you to hold your breath for up to 1 hour.<br/>
+        <span class="feature">Wavering Emotions.</span>Your mood affects your ability to sing and fly. After any short or long rest, you must choose whether you are feeling joyful or sad. While you are feeling sad, you lose your flying speed but gain <i>songs of sorrow</i>. While you are feeling joyful, you gain your flying speed but lose <i>songs of sorrow</i>. Your mood may change before the next time you rest, but it won’t affect which ability you have access to until after your next rest is completed.<br/>
+        <span class="feature">Flight.</span>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.<br/>
+        <span class="feature">Songs of Sorrow.</span>Your lamentations have a powerful effect on anyone who can hear them. You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 3rd level, you can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 5th level, you can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
+      </p>
+    </description>
+    <sheet display="false" />
+    <setters>
+
+    </setters>
+    <rules>
+      <stat name="dexterity" value="1"/>
+      <stat name="charisma" value="2"/>
+      <stat name="innate speed" value="30" bonus="base"/>
+      <grant type="Size" id="ID_SIZE_MEDIUM" />
+      <grant type="Language" id="ID_LANGUAGE_COMMON" />
+      <grant type="Language" id="ID_LANGUAGE_CELESTIAL" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_ENTHRALLING_VOICE" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_WAVERING_EMOTIONS" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_FLIGHT" />
+      <grant type="Racial Trait" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_SONGS_OF_SORROW" />
+    </rules>
+  </element>
+
+  <element name="Enthralling Voice" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_ENTHRALLING_VOICE">
+    <supports />
+    <description>
+      <p>You have advantage on Performance and Persuasion checks made with your voice. Additionally, your powerful lungs allow you to hold your breath for up to 1 hour.</p>
+    </description>
+    <sheet>
+      <description>You have advantage on Performance and Persuasion checks made with your voice. Additionally, your powerful lungs allow you to hold your breath for up to 1 hour.</description>
+    </sheet>
+    <rules/>
+  </element>
+
+  <element name="Wavering Emotions" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_WAVERING_EMOTIONS">
+    <supports />
+    <description>
+      <p>Your mood affects your ability to sing and fly. After any short or long rest, you must choose whether you are feeling joyful or sad. While you are feeling sad, you lose your flying speed but gain <i>songs of sorrow</i>. While you are feeling joyful, you gain your flying speed but lose <i>songs of sorrow</i>. Your mood may change before the next time you rest, but it won’t affect which ability you have access to until after your next rest is completed.</p>
+    </description>
+    <sheet>
+      <description>Your mood affects your ability to sing and fly. After any short or long rest, you must choose whether you are feeling joyful or sad. While you are feeling sad, you lose your flying speed but gain <i>songs of sorrow</i>. While you are feeling joyful, you gain your flying speed but lose <i>songs of sorrow</i>. Your mood may change before the next time you rest, but it won’t affect which ability you have access to until after your next rest is completed.</description>
+    </sheet>
+    <rules/>
+  </element>
+
+  <element name="Flight" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_FLIGHT">
+    <supports />
+    <description>
+      <p>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</p>
+    </description>
+    <sheet>
+      <description>You have a flying speed of 30 feet. To use this speed, you can’t be wearing medium or heavy armor.</description>
+    </sheet>
+    <rules/>
+  </element>
+
+  <element name="Songs of Sorrow" type="Racial Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_RACIAL_TRAIT_THYLEAN_SIREN_SONGS_OF_SORROW">
+    <supports />
+    <description>
+      <p>Your lamentations have a powerful effect on anyone who can hear them. You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 3rd level, you can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. When you reach 5th level, you can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.</p>
+    </description>
+    <sheet>
+      <description>
+        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for this spell, and the targets of your spell must have the ability to hear you singing.
+      </description>
+      <description level="3">
+        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
+      </description>
+      <description level="5">
+        You can cast the <i>charm person</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>enthrall</i> spell once with this trait and regain the ability to do so when you finish a short rest. You can cast the <i>hold person</i> spell once with this trait and regain the ability to do so when you finish a short rest. Charisma is your spellcasting ability for these spells, and the targets of your spells must have the ability to hear you singing.
+      </description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" />
+      <grant type="Spell" id="ID_PHB_SPELL_ENTHRALL" level="3" />
+      <grant type="Spell" id="ID_PHB_SPELL_HOLD_PERSON" level="5" />
+    </rules>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
@@ -12,7 +12,7 @@
 		<setters>
 			<set name="abbreviation">OOTD</set>
 			<set name="url">https://www.drivethrurpg.com/product/267073/Odyssey-of-the-Dragonlords-Players-Guide</set>
-			<set name="image">https://cdn.shopify.com/s/files/1/0225/4035/products/PlayersGuideCover.jpg?v=1574099763</set>
+			<set name="image">https://www.drivethrurpg.com/images/4329/267073.jpg</set>
 			<set name="author" abbreviation="AW" url="https://www.arcanumworlds.com/">Arcanum Worlds</set>
 			<set name="third-party">true</set>
 			<set name="incomplete">true</set>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<update version="0.1">
+			<file name="source.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml" />
+		</update>
+	</info>
+	<element name="Odyssey of the Dragonlords" type="Source" source="Core" id="ID_SOURCE_ODYSSEY_OF_THE_DRAGONLORDS">
+		<description>
+			<![CDATA[<p>Odyssey of the Dragonlords is an epic adventure book for the 5th Edition of the world's greatest roleplaying game.</p>]]>
+		</description>
+		<setters>
+			<set name="abbreviation">OOTD</set>
+			<set name="url">https://www.drivethrurpg.com/product/267073/Odyssey-of-the-Dragonlords-Players-Guide</set>
+			<set name="image">https://cdn.shopify.com/s/files/1/0225/4035/products/PlayersGuideCover.jpg?v=1574099763</set>
+			<set name="author" abbreviation="AW" url="https://www.arcanumworlds.com/">Arcanum Worlds</set>
+			<set name="third-party">true</set>
+		</setters>
+	</element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/source.xml
@@ -15,6 +15,7 @@
 			<set name="image">https://cdn.shopify.com/s/files/1/0225/4035/products/PlayersGuideCover.jpg?v=1574099763</set>
 			<set name="author" abbreviation="AW" url="https://www.arcanumworlds.com/">Arcanum Worlds</set>
 			<set name="third-party">true</set>
+			<set name="incomplete">true</set>
 		</setters>
 	</element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml
@@ -2,10 +2,9 @@
 <elements>
     <info>
 		  <update version="0.0.1">
-			  <file name="aw-ootd-spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/aw-ootd-spells.xml" />
+			  <file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml" />
 		  </update>
 	</info>
-
   <element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
     <supports>Druid, Ranger, Sorcerer</supports>
     <description>
@@ -29,7 +28,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Bond of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_BOND_OF_THE_DRAGONLORDS">
     <supports>Paladin</supports>
     <description>
@@ -54,7 +52,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Dirge of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_DIRGE_OF_THE_DRAGONLORDS">
     <supports>Bard, Cleric, Paladin</supports>
     <description>
@@ -76,7 +73,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Fatebinding" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_FATEBINDING">
     <supports>Bard, Cleric, Warlock, Wizard</supports>
     <description>
@@ -102,7 +98,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Seeds of Death" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SEEDS_OF_DEATH">
     <supports>Druid, Sorcerer, Warlock, Wizard</supports>
     <description>
@@ -124,7 +119,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Sleeping Draught" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SLEEPING_DRAUGHT">
     <supports>Bard, Warlock, Wizard</supports>
     <description>
@@ -147,7 +141,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Sword of Fate" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SWORD_OF_FATE">
     <supports>Bard, Cleric, Warlock, Wizard</supports>
     <description>
@@ -175,7 +168,6 @@
       <set name="isRitual">false</set>
     </setters>
   </element>
-
   <element name="Theogenesis" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_THEOGENESIS">
     <supports>Cleric, Sorcerer, Wizard</supports>
     <description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml
@@ -1,199 +1,199 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
-    <info>
-		  <update version="0.0.1">
-			  <file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml" />
-		  </update>
+	<info>
+		<update version="0.0.1">
+			<file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/spells.xml" />
+		</update>
 	</info>
-  <element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
-    <supports>Druid, Ranger, Sorcerer</supports>
-    <description>
-      <p>This spell transforms a creature you can see within range into a new beast form. An unwilling creature must make a Wisdom saving throw to avoid the effect. A shapechanger automatically succeeds on this saving throw.</p>
-      <p class="indent">The transformation lasts for the duration, or until the target drops to 0 hit points or dies. The new form can be any beast of CR 1 or less that does not have a fly speed. While in this new form, the target is charmed by you and views you as a trusted ally. The target can understand simple commands such as “attack” or “stay.” The charm affects creatures that are immune to charm in their normal form. The charm ends immediately when the target reverts to its normal form.</p>
-      <p class="indent">The target’s game statistics, including mental ability scores, are replaced by the statistics of the chosen beast. It retains its alignment and personality. The creature is limited in the actions it can perform by the nature of its new form, and it can’t speak, cast spells, or take any other action that requires hands or speech. The creature's gear melds into its new form. The creature can’t activate, use, wield, or otherwise benefit from any of its equipment.</p>
-      <p class="indent">The target assumes the hit points of its new form. When it reverts to its normal form, the creature returns to the number of hit points it had before it transformed. If it reverts as a result of dropping to 0 hit points, any excess damage carries over to its normal form.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">3</set>
-      <set name="school">Transmutation</set>
-      <set name="time">1 action</set>
-      <set name="duration">Concentration, up to 10 minutes</set>
-      <set name="range">60 feet</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">true</set>
-      <set name="hasMaterialComponent">false</set>
-      <set name="materialComponent" />
-      <set name="isConcentration">true</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Bond of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_BOND_OF_THE_DRAGONLORDS">
-    <supports>Paladin</supports>
-    <description>
-      <p>You permanently bond with a newly-hatched metallic dragon. This requires you to locate an unhatched dragon egg and spend 1d4 days nurturing the egg so that it hatches. The hatchling may be any of the following types of dragon wyrmling: brass, bronze, copper, or silver.</p>
-      <p class="indent">You can confer the bond to another recipient who you are touching when you cast the spell. A dragon that has been bonded can never be bonded with another target. Likewise, this spell cannot be used to bond more than one dragon to any individual.</p>
-      <p class="indent">Wyrmlings cannot be used as mounts until they grow into young dragons. A dragon cannot use legendary actions while it is being used as a mount.</p>
-      <p class="indent"><b><i>Controlling the Dragon.</i></b> Your dragon moves and acts on your initiative. You can decide how the dragon moves and attacks. While your dragon is fighting alongside you, it loses its multiattack feature. If your dragon has a breath weapon, it can be used once, and it recharges after you and the dragon complete a long rest.</p>
-      <p class="indent">If your bonded dragon dies, you will also die within 24 hours unless the dragon is returned to life. You cannot be raised from the dead unless your bonded dragon is alive. The same is true for your dragon.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">2</set>
-      <set name="school">Enchantment</set>
-      <set name="time">1 minute</set>
-      <set name="duration">Special</set>
-      <set name="range">Touch</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">false</set>
-      <set name="hasMaterialComponent">true</set>
-      <set name="materialComponent">magical armor, shield, weapon, ring, rod, staff, or wand worth at least 5,000 gp, which the spell consumes, and an unhatched dragon egg</set>
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Dirge of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_DIRGE_OF_THE_DRAGONLORDS">
-    <supports>Bard, Cleric, Paladin</supports>
-    <description>
-      <p>You return a dead dragon that has been bonded to a Dragonlord back to life. The dragon returns to life with 1 hit point. All of the dragon's mortal wounds are closed, and any missing body parts are restored.</p>
-      <p class="indent">This spell also neutralizes any poisons and cures nonmagical diseases that affected the dragon at the time it died. This spell doesn’t, however, remove magical diseases, curses, or similar effects; if these aren’t first removed prior to casting the spell, they take effect when the dragon returns to life.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">3</set>
-      <set name="school">Necromancy</set>
-      <set name="time">1 hour</set>
-      <set name="duration">Instantaneous</set>
-      <set name="range">Touch</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">false</set>
-      <set name="hasMaterialComponent">true</set>
-      <set name="materialComponent">an offering of gems and coins worth at least 1,000 gp, which the spell consumes</set>
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Fatebinding" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_FATEBINDING">
-    <supports>Bard, Cleric, Warlock, Wizard</supports>
-    <description>
-      <p>Choose two creatures that you can see. Both creatures must make Charisma saving throws, and they do so with advantage if they are hostile to you. If a creature is charmed by you, it has disadvantage on this saving throw. If both creatures fail their saving throws, then their fates are now bound together.</p>
-      <ul>
-        <li>Whenever one of the creatures takes damage, the other creature takes an identical amount of damage, unless both creatures took damage from the same single source, such as a <i>fireball</i> spell.</li>
-        <li>Whenever one of the creatures regains hit points, the other creature regains an identical number of hit points, unless both creatures regained hit points from the same single source, such as <i>mass cure wounds</i>.</li>
-      </ul>
-      <p>The two target creatures remain fate-bound for the duration of the spell, even if both targets are on different planes of existence.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">3</set>
-      <set name="school">Necromancy</set>
-      <set name="time">1 action</set>
-      <set name="duration">1 hour</set>
-      <set name="range">30 feet</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">false</set>
-      <set name="hasMaterialComponent">false</set>
-      <set name="materialComponent" />
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Seeds of Death" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SEEDS_OF_DEATH">
-    <supports>Druid, Sorcerer, Warlock, Wizard</supports>
-    <description>
-      <p>You throw three minotaur teeth on to the ground in front of you. At the start of your next turn, three <b>minotaur skeletons</b> erupt from the ground, fully formed. You can use a bonus action to shout commands at the minotaur skeletons if they are within 100 ft. of you. Your commands must be general orders, such as "attack that enemy" or "guard this room." Once given an order, the minotaur skeletons will continue to follow it until the task is complete or until you issue another command. If the minotaur skeletons are given no commands, they will attack the nearest creature. When the spell ends, the minotaur skeletons dissolve into bone dust.</p>
-      <p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th level or higher, you animate an extra minotaur skeleton for each slot level above 6th.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">6</set>
-      <set name="school">Necromancy</set>
-      <set name="time">1 action</set>
-      <set name="duration">Concentration, up to 10 minutes</set>
-      <set name="range">30 feet</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">true</set>
-      <set name="hasMaterialComponent">true</set>
-      <set name="materialComponent">three or more minotaur teeth and alchemical fertilizer worth 100 gp</set>
-      <set name="isConcentration">true</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Sleeping Draught" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SLEEPING_DRAUGHT">
-    <supports>Bard, Warlock, Wizard</supports>
-    <description>
-      <p>You open a draught and a purple mist flows from you to a target creature. Roll 9d8; if the target creature has fewer current hit points than the total, then it falls unconscious. The target remains unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. If the target creature has more hit points than the rolled total, then it becomes drowsy and its speed is halved, it can’t take reactions, and it can’t make more than one melee or ranged attack during its turn. The target remains drowsy until it takes damage or until the spell ends.</p>
-      <p class="indent">Undead and creatures that are immune to being charmed aren’t affected by this spell.</p>
-      <p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, roll an additional 3d8 for each slot level above the 2nd.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">2</set>
-      <set name="school">Enchantment</set>
-      <set name="time">1 action</set>
-      <set name="duration">1 minute</set>
-      <set name="range">20 feet</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">true</set>
-      <set name="hasMaterialComponent">true</set>
-      <set name="materialComponent">a draught of liquid</set>
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Sword of Fate" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SWORD_OF_FATE">
-    <supports>Bard, Cleric, Warlock, Wizard</supports>
-    <description>
-      <p>Choose a creature that you can see. You create an illusionary sword that hangs above that creature's head. Everyone with line of sight can see the sword except for the affected creature. When you cast the spell you must shout out one of the following conditions:</p>
-      <ul>
-        <li><i>You cannot harm us.</i> The target creature breaks this condition if they target the spell caster or a companion with an attack or a spell that causes damage.</li>
-        <li><i>You cannot use magic.</i> The target creature breaks this condition if they cast a spell.</li>
-        <li><i>You cannot leave this area.</i> The target creature breaks this condition if it moves more than 30 feet from the spot it was standing when the spell was cast.</li>
-      </ul>
-      <p class="indent">If the target creature breaks the condition, it takes 10d8 slashing damage as the blade becomes real and slices downward. If the target is reduced to 0 hit points, then one of its heads is removed. If the creature has no remaining heads, then it is instantly killed.</p>
-      <p class="indent">The sword of fate can be dispelled. In addition, remove curse will end the spell on the target.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">5</set>
-      <set name="school">Illusion</set>
-      <set name="time">1 action</set>
-      <set name="duration">1 hour</set>
-      <set name="range">60 feet</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">false</set>
-      <set name="hasMaterialComponent">false</set>
-      <set name="materialComponent" />
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
-  <element name="Theogenesis" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_THEOGENESIS">
-    <supports>Cleric, Sorcerer, Wizard</supports>
-    <description>
-      <p><i>Theogenesis</i> is a powerful spell that is used to place a divine spark into a mortal creature, unlocking the potential to ascend to godhood. The artifacts are not consumed when the spell is cast, but the offerings are.</p>
-      <p class="indent">Choose a single target (non-divine) creature for the spell. You must remain in contact with the target for the duration of the casting. If contact is broken, both you and the target take 20d6 radiant damage, and both the spell and the offering are wasted. If the spell is successfully cast, then one of the greater gods must decide whether or not to grant the divine spark. The creature's relationship with the god determines its chance of success, and the base chance is 0%. Each of the bonuses below are cumulative:</p>
-      <ul>
-        <li>The target shares at least one alignment axis with the greater god: +20%</li>
-        <li>The target has the exact same alignment as the greater god: +20%</li>
-        <li>The target has faithfully worshipped a god in the same pantheon for at least a year: +20%</li>
-        <li>The target has faithfully worshipped the greater god for at least a year: +30%</li>
-      </ul>
-      <p class="indent">Failure means that the greater god decides not to grant the divine spark. That greater god can’t be chosen again if the spell is cast on the same target. Success means that the target has been permanently granted a divine spark. It can only be removed with a wish spell.</p>
-    </description>
-    <setters>
-      <set name="keywords"></set>
-      <set name="level">9</set>
-      <set name="school">Conjuration</set>
-      <set name="time">1 hour</set>
-      <set name="duration">Special</set>
-      <set name="range">Touch</set>
-      <set name="hasVerbalComponent">true</set>
-      <set name="hasSomaticComponent">true</set>
-      <set name="hasMaterialComponent">true</set>
-      <set name="materialComponent">offerings worth at least 10,000 gp, which are consumed, and all three Divine Artifacts: the Caduceus, the Ambrosia, and the Promethean fire</set>
-      <set name="isConcentration">false</set>
-      <set name="isRitual">false</set>
-    </setters>
-  </element>
+	<element name="Animal Polymorph" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_ANIMAL_POLYMORPH">
+		<supports>Druid, Ranger, Sorcerer</supports>
+		<description>
+			<p>This spell transforms a creature you can see within range into a new beast form. An unwilling creature must make a Wisdom saving throw to avoid the effect. A shapechanger automatically succeeds on this saving throw.</p>
+			<p class="indent">The transformation lasts for the duration, or until the target drops to 0 hit points or dies. The new form can be any beast of CR 1 or less that does not have a fly speed. While in this new form, the target is charmed by you and views you as a trusted ally. The target can understand simple commands such as “attack” or “stay.” The charm affects creatures that are immune to charm in their normal form. The charm ends immediately when the target reverts to its normal form.</p>
+			<p class="indent">The target’s game statistics, including mental ability scores, are replaced by the statistics of the chosen beast. It retains its alignment and personality. The creature is limited in the actions it can perform by the nature of its new form, and it can’t speak, cast spells, or take any other action that requires hands or speech. The creature's gear melds into its new form. The creature can’t activate, use, wield, or otherwise benefit from any of its equipment.</p>
+			<p class="indent">The target assumes the hit points of its new form. When it reverts to its normal form, the creature returns to the number of hit points it had before it transformed. If it reverts as a result of dropping to 0 hit points, any excess damage carries over to its normal form.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">3</set>
+			<set name="school">Transmutation</set>
+			<set name="time">1 action</set>
+			<set name="duration">Concentration, up to 10 minutes</set>
+			<set name="range">60 feet</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent" />
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Bond of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_BOND_OF_THE_DRAGONLORDS">
+		<supports>Paladin</supports>
+		<description>
+			<p>You permanently bond with a newly-hatched metallic dragon. This requires you to locate an unhatched dragon egg and spend 1d4 days nurturing the egg so that it hatches. The hatchling may be any of the following types of dragon wyrmling: brass, bronze, copper, or silver.</p>
+			<p class="indent">You can confer the bond to another recipient who you are touching when you cast the spell. A dragon that has been bonded can never be bonded with another target. Likewise, this spell cannot be used to bond more than one dragon to any individual.</p>
+			<p class="indent">Wyrmlings cannot be used as mounts until they grow into young dragons. A dragon cannot use legendary actions while it is being used as a mount.</p>
+			<p class="indent"><b><i>Controlling the Dragon.</i></b> Your dragon moves and acts on your initiative. You can decide how the dragon moves and attacks. While your dragon is fighting alongside you, it loses its multiattack feature. If your dragon has a breath weapon, it can be used once, and it recharges after you and the dragon complete a long rest.</p>
+			<p class="indent">If your bonded dragon dies, you will also die within 24 hours unless the dragon is returned to life. You cannot be raised from the dead unless your bonded dragon is alive. The same is true for your dragon.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">2</set>
+			<set name="school">Enchantment</set>
+			<set name="time">1 minute</set>
+			<set name="duration">Special</set>
+			<set name="range">Touch</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">magical armor, shield, weapon, ring, rod, staff, or wand worth at least 5,000 gp, which the spell consumes, and an unhatched dragon egg</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Dirge of the Dragonlords" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_DIRGE_OF_THE_DRAGONLORDS">
+		<supports>Bard, Cleric, Paladin</supports>
+		<description>
+			<p>You return a dead dragon that has been bonded to a Dragonlord back to life. The dragon returns to life with 1 hit point. All of the dragon's mortal wounds are closed, and any missing body parts are restored.</p>
+			<p class="indent">This spell also neutralizes any poisons and cures nonmagical diseases that affected the dragon at the time it died. This spell doesn’t, however, remove magical diseases, curses, or similar effects; if these aren’t first removed prior to casting the spell, they take effect when the dragon returns to life.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">3</set>
+			<set name="school">Necromancy</set>
+			<set name="time">1 hour</set>
+			<set name="duration">Instantaneous</set>
+			<set name="range">Touch</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">an offering of gems and coins worth at least 1,000 gp, which the spell consumes</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Fatebinding" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_FATEBINDING">
+		<supports>Bard, Cleric, Warlock, Wizard</supports>
+		<description>
+			<p>Choose two creatures that you can see. Both creatures must make Charisma saving throws, and they do so with advantage if they are hostile to you. If a creature is charmed by you, it has disadvantage on this saving throw. If both creatures fail their saving throws, then their fates are now bound together.</p>
+			<ul>
+				<li>Whenever one of the creatures takes damage, the other creature takes an identical amount of damage, unless both creatures took damage from the same single source, such as a <i>fireball</i> spell.</li>
+				<li>Whenever one of the creatures regains hit points, the other creature regains an identical number of hit points, unless both creatures regained hit points from the same single source, such as <i>mass cure wounds</i>. </li>
+			</ul>
+			<p>The two target creatures remain fate-bound for the duration of the spell, even if both targets are on different planes of existence.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">3</set>
+			<set name="school">Necromancy</set>
+			<set name="time">1 action</set>
+			<set name="duration">1 hour</set>
+			<set name="range">30 feet</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent" />
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Seeds of Death" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SEEDS_OF_DEATH">
+		<supports>Druid, Sorcerer, Warlock, Wizard</supports>
+		<description>
+			<p>You throw three minotaur teeth on to the ground in front of you. At the start of your next turn, three <b>minotaur skeletons</b> erupt from the ground, fully formed. You can use a bonus action to shout commands at the minotaur skeletons if they are within 100 ft. of you. Your commands must be general orders, such as "attack that enemy" or "guard this room." Once given an order, the minotaur skeletons will continue to follow it until the task is complete or until you issue another command. If the minotaur skeletons are given no commands, they will attack the nearest creature. When the spell ends, the minotaur skeletons dissolve into bone dust.</p>
+			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 7th level or higher, you animate an extra minotaur skeleton for each slot level above 6th.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">6</set>
+			<set name="school">Necromancy</set>
+			<set name="time">1 action</set>
+			<set name="duration">Concentration, up to 10 minutes</set>
+			<set name="range">30 feet</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">three or more minotaur teeth and alchemical fertilizer worth 100 gp</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Sleeping Draught" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SLEEPING_DRAUGHT">
+		<supports>Bard, Warlock, Wizard</supports>
+		<description>
+			<p>You open a draught and a purple mist flows from you to a target creature. Roll 9d8; if the target creature has fewer current hit points than the total, then it falls unconscious. The target remains unconscious until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake. If the target creature has more hit points than the rolled total, then it becomes drowsy and its speed is halved, it can’t take reactions, and it can’t make more than one melee or ranged attack during its turn. The target remains drowsy until it takes damage or until the spell ends.</p>
+			<p class="indent">Undead and creatures that are immune to being charmed aren’t affected by this spell.</p>
+			<p class="indent"><b><i>At Higher Levels.</i></b> When you cast this spell using a spell slot of 3rd level or higher, roll an additional 3d8 for each slot level above the 2nd.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">2</set>
+			<set name="school">Enchantment</set>
+			<set name="time">1 action</set>
+			<set name="duration">1 minute</set>
+			<set name="range">20 feet</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">a draught of liquid</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Sword of Fate" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_SWORD_OF_FATE">
+		<supports>Bard, Cleric, Warlock, Wizard</supports>
+		<description>
+			<p>Choose a creature that you can see. You create an illusionary sword that hangs above that creature's head. Everyone with line of sight can see the sword except for the affected creature. When you cast the spell you must shout out one of the following conditions:</p>
+			<ul>
+				<li><i>You cannot harm us.</i> The target creature breaks this condition if they target the spell caster or a companion with an attack or a spell that causes damage.</li>
+				<li><i>You cannot use magic.</i> The target creature breaks this condition if they cast a spell.</li>
+				<li><i>You cannot leave this area.</i> The target creature breaks this condition if it moves more than 30 feet from the spot it was standing when the spell was cast.</li>
+			</ul>
+			<p class="indent">If the target creature breaks the condition, it takes 10d8 slashing damage as the blade becomes real and slices downward. If the target is reduced to 0 hit points, then one of its heads is removed. If the creature has no remaining heads, then it is instantly killed.</p>
+			<p class="indent">The sword of fate can be dispelled. In addition, remove curse will end the spell on the target.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">5</set>
+			<set name="school">Illusion</set>
+			<set name="time">1 action</set>
+			<set name="duration">1 hour</set>
+			<set name="range">60 feet</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent" />
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Theogenesis" type="Spell" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_SPELL_THEOGENESIS">
+		<supports>Cleric, Sorcerer, Wizard</supports>
+		<description>
+			<p><i>Theogenesis</i> is a powerful spell that is used to place a divine spark into a mortal creature, unlocking the potential to ascend to godhood. The artifacts are not consumed when the spell is cast, but the offerings are.</p>
+			<p class="indent">Choose a single target (non-divine) creature for the spell. You must remain in contact with the target for the duration of the casting. If contact is broken, both you and the target take 20d6 radiant damage, and both the spell and the offering are wasted. If the spell is successfully cast, then one of the greater gods must decide whether or not to grant the divine spark. The creature's relationship with the god determines its chance of success, and the base chance is 0%. Each of the bonuses below are cumulative:</p>
+			<ul>
+				<li>The target shares at least one alignment axis with the greater god: +20%</li>
+				<li>The target has the exact same alignment as the greater god: +20%</li>
+				<li>The target has faithfully worshipped a god in the same pantheon for at least a year: +20%</li>
+				<li>The target has faithfully worshipped the greater god for at least a year: +30%</li>
+			</ul>
+			<p class="indent">Failure means that the greater god decides not to grant the divine spark. That greater god can’t be chosen again if the spell is cast on the same target. Success means that the target has been permanently granted a divine spark. It can only be removed with a wish spell.</p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">9</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 hour</set>
+			<set name="duration">Special</set>
+			<set name="range">Touch</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">offerings worth at least 10,000 gp, which are consumed, and all three Divine Artifacts: the Caduceus, the Ambrosia, and the Promethean fire</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
@@ -8,9 +8,7 @@
   <element name="Herculean Path" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_BARBARIAN_HERCULEAN_PATH">
     <supports>Primal Path</supports>
     <description>
-      <p>
-        Some individuals are born with seemingly impossible strength, exhibiting rippling muscles even before they learn to speak or walk. Such men and women quickly learn that every good thing in this world may be obtained through the exercise of overwhelming might. Others may scorn them and call them “barbaric,” but what are words but useless noise to be choked out of the speaker’s windpipe?
-      </p>
+      <p>Some individuals are born with seemingly impossible strength, exhibiting rippling muscles even before they learn to speak or walk. Such men and women quickly learn that every good thing in this world may be obtained through the exercise of overwhelming might. Others may scorn them and call them “barbaric,” but what are words but useless noise to be choked out of the speaker’s windpipe?</p>
       <p class="indent">As one such individual, you know that strength is what determines one’s worth in the world: strength to crush your enemies—and to impress your allies. You savor the opportunity to show off your great strength, whether it be in battle or in friendly competition. Your incredible strength allows you to accomplish Herculean feats that will leave your foes wailing in anguish.</p>
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_MIGHTY_MARKSMAN" />
@@ -18,8 +16,7 @@
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER" />
     </description>
     <sheet display="false">
-      <description>
-        Some individuals are born with seemingly impossible strength.</description>
+      <description>Some individuals are born with seemingly impossible strength.</description>
     </sheet>
     <rules>
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER" level="3" />
@@ -28,7 +25,6 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER" level="14" />
     </rules>
   </element>
-
   <element name="Precocious Wrestler" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER">
     <description>
       <p>Starting at 3rd level, you have learned to take advantage of your innate strength to wrestle foes into submission. You are proficient in the Athletics skill, and you are capable of grappling and shoving creatures that are up to two sizes larger than you. On your turn, you may use a bonus action to attempt to grapple a creature. While you are grappling a creature with one hand, you may use your free hand to attack that creature with two-handed weapons as if you were using both hands.</p>
@@ -40,13 +36,10 @@
       <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_ATHLETICS" />
     </rules>
   </element>
-
   <element name="Mighty Marksman" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_MIGHTY_MARKSMAN">
     <description>
-      <p>
-        Starting at 6th level, you leverage your immense strength when using ranged weapons. You can use heavy weapons without incurring disadvantage due to your size. Additionally, you may choose to use your Strength modifier for attack and damage rolls with longbows. When you make ranged attacks with longbows or thrown weapons while raging, you may add your rage damage bonus to the damage rolls.<br/>
-        <b>Thunderous Shot.</b> When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is 8 + your proficiency bonus + your Strength modifier. Once you have used this feature, you may not use it again until you complete a short or long rest.
-      </p>
+      <p>Starting at 6th level, you leverage your immense strength when using ranged weapons. You can use heavy weapons without incurring disadvantage due to your size. Additionally, you may choose to use your Strength modifier for attack and damage rolls with longbows. When you make ranged attacks with longbows or thrown weapons while raging, you may add your rage damage bonus to the damage rolls.</p>
+      <p class="indent"><strong><em>Thunderous Shot.</em></strong> When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is 8 + your proficiency bonus + your Strength modifier. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
     </description>
     <sheet>
       <description>
@@ -59,7 +52,17 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT" />
     </rules>
   </element>
-
+  <element name="Thunderous Shot" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT">
+    <compendium display="false" />
+    <sheet>
+      <description usage="1/Short Rest">When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is {{mighty marksman:dc}}.</description>
+    </sheet>
+    <rules>
+      <stat name="mighty marksman:dc" value="8" />
+      <stat name="mighty marksman:dc" value="strength:modifier" />
+      <stat name="mighty marksman:dc" value="proficiency" />
+    </rules>
+  </element>
   <element name="Herculean Rage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE">
     <description>
       <p>Starting at 10th level, your rages take on legendary qualities and grow more powerful the longer they endure. At the beginning of each of your turns, if you are already raging, your rage damage bonus increases by +1, up to a maximum of your Strength modifier. Additionally, while raging, you are immune to poison damage and you cannot be frightened.</p>
@@ -68,40 +71,21 @@
       <description>At the beginning of each of your turns, if you are already raging, your rage damage bonus increases by +1, up to a maximum of a +{{strength:modifier}} increase. Additionally, while raging, you are immune to poison damage and you cannot be frightened.</description>
     </sheet>
   </element>
-
   <element name="Earthshaker" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER">
     <description>
-      <p>
-        Starting at 14th level, your colossal strength causes the ground itself to tremble and quake. On your turn, you can use your action to strike the ground and create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.<br/>
-        Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of 8 + your proficiency bonus + your Strength modifier. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.<br/>
-        At the beginning of each of your subsequent turns, you may use your bonus action to stomp the ground and continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute. Once you have used this feature, you may not use it again until you complete a long rest.
-      </p>
+      <p>Starting at 14th level, your colossal strength causes the ground itself to tremble and quake. On your turn, you can use your action to strike the ground and create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.</p>
+      <p class="indent">Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of 8 + your proficiency bonus + your Strength modifier. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.</p>
+      <p class="indent">At the beginning of each of your subsequent turns, you may use your bonus action to stomp the ground and continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute. Once you have used this feature, you may not use it again until you complete a long rest.</p>
     </description>
     <sheet>
-      <description action="Action" usage="1/Long Rest">
-        Create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.<br/>
-        Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of {{earthshaker:dc}}. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.<br/>
-        At the beginning of each of your subsequent turns, you may use your bonus action to continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute.
-      </description>
+      <description action="Action" usage="1/Long Rest">Create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.
+        Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of {{earthshaker:dc}}. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.
+        At the beginning of each of your subsequent turns, you may use your bonus action to continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute.</description>
     </sheet>
     <rules>
       <stat name="earthshaker:dc" value="8" />
       <stat name="earthshaker:dc" value="strength:modifier" />
       <stat name="earthshaker:dc" value="proficiency" />
-    </rules>
-  </element>
-
-  <!-- subfeatures -->
-  <element name="Thunderous Shot" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT">
-    <sheet>
-      <description usage="1/Short Rest">
-        When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is {{mighty marksman:dc}}.
-      </description>
-    </sheet>
-    <rules>
-      <stat name="mighty marksman:dc" value="8" />
-      <stat name="mighty marksman:dc" value="strength:modifier" />
-      <stat name="mighty marksman:dc" value="proficiency" />
     </rules>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
@@ -1,0 +1,107 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-barbarian-herculean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml" />
+		</update>
+	</info>
+  <element name="Herculean Path" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_BARBARIAN_HERCULEAN_PATH">
+    <supports>Primal Path</supports>
+    <description>
+      <p>
+        Some individuals are born with seemingly impossible strength, exhibiting rippling muscles even before they learn to speak or walk. Such men and women quickly learn that every good thing in this world may be obtained through the exercise of overwhelming might. Others may scorn them and call them “barbaric,” but what are words but useless noise to be choked out of the speaker’s windpipe?
+      </p>
+      <p class="indent">As one such individual, you know that strength is what determines one’s worth in the world: strength to crush your enemies—and to impress your allies. You savor the opportunity to show off your great strength, whether it be in battle or in friendly competition. Your incredible strength allows you to accomplish Herculean feats that will leave your foes wailing in anguish.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_MIGHTY_MARKSMAN" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER" />
+    </description>
+    <sheet display="true">
+      <description>
+        Some individuals are born with seemingly impossible strength.</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_MIGHTY_MARKSMAN" level="6" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE" level="10" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER" level="14" />
+    </rules>
+  </element>
+
+  <element name="Precocious Wrestler" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_PRECOCIOUS_WRESTLER">
+    <description>
+      <p>Starting at 3rd level, you have learned to take advantage of your innate strength to wrestle foes into submission. You are proficient in the Athletics skill, and you are capable of grappling and shoving creatures that are up to two sizes larger than you. On your turn, you may use a bonus action to attempt to grapple a creature. While you are grappling a creature with one hand, you may use your free hand to attack that creature with two-handed weapons as if you were using both hands.</p>
+    </description>
+    <sheet>
+      <description action="Bonus Action">Attempt to grapple a creature. While you are grappling a creature with one hand, you may use your free hand to attack that creature with two-handed weapons as if you were using both hands. You are capable of grappling and shoving creatures that are up to two sizes larger than you.</description>
+    </sheet>
+    <rules>
+      <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_ATHLETICS" />
+    </rules>
+  </element>
+
+  <element name="Mighty Marksman" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_MIGHTY_MARKSMAN">
+    <description>
+      <p>
+        Starting at 6th level, you leverage your immense strength when using ranged weapons. You can use heavy weapons without incurring disadvantage due to your size. Additionally, you may choose to use your Strength modifier for attack and damage rolls with longbows. When you make ranged attacks with longbows or thrown weapons while raging, you may add your rage damage bonus to the damage rolls.<br/>
+        <b>Thunderous Shot.</b> When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is 8 + your proficiency bonus + your Strength modifier. Once you have used this feature, you may not use it again until you complete a short or long rest.
+      </p>
+    </description>
+    <sheet>
+      <description>
+        You can use heavy weapons without incurring disadvantage due to your size. Additionally, when using a longbow, you may choose to use your Strength modifier for attack rolls (ranged attack {{mighty marksman:attack}}) and damage rolls (+{{strength:modifier}}). When you make ranged attacks with longbows or thrown weapons while raging, you may add your rage bonus (base +{{barbarian rage:damage}}) to the damage rolls.
+      </description>
+    </sheet>
+    <rules>
+      <stat name="mighty marksman:attack" value="strength:modifier" />
+      <stat name="mighty marksman:attack" value="proficiency" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT" />
+    </rules>
+  </element>
+
+  <element name="Thunderous Shot" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT">
+    <sheet>
+      <description usage="1/Short Rest">
+        When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is {{mighty marksman:dc}}.
+      </description>
+    </sheet>
+    <rules>
+      <stat name="mighty marksman:dc" value="8" />
+      <stat name="mighty marksman:dc" value="strength:modifier" />
+      <stat name="mighty marksman:dc" value="proficiency" />
+    </rules>
+  </element>
+
+  <element name="Herculean Rage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE">
+    <description>
+      <p>Starting at 10th level, your rages take on legendary qualities and grow more powerful the longer they endure. At the beginning of each of your turns, if you are already raging, your rage damage bonus increases by +1, up to a maximum of your Strength modifier. Additionally, while raging, you are immune to poison damage and you cannot be frightened.</p>
+    </description>
+    <sheet>
+      <description>At the beginning of each of your turns, if you are already raging, your rage damage bonus increases by +1, up to a maximum of a +{{strength:modifier}} increase. Additionally, while raging, you are immune to poison damage and you cannot be frightened.</description>
+    </sheet>
+  </element>
+
+  <element name="Earthshaker" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER">
+    <description>
+      <p>
+        Starting at 14th level, your colossal strength causes the ground itself to tremble and quake. On your turn, you can use your action to strike the ground and create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.<br/>
+        Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of 8 + your proficiency bonus + your Strength modifier. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.<br/>
+        At the beginning of each of your subsequent turns, you may use your bonus action to stomp the ground and continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute. Once you have used this feature, you may not use it again until you complete a long rest.
+      </p>
+    </description>
+    <sheet>
+      <description action="Action" usage="1/Long Rest">
+        Create the effects of an earthquake with a 40 ft. radius, centered on your location. This area becomes difficult terrain.<br/>
+        Each creature on the ground in the affected area that is concentrating must make a Constitution saving throw with a DC of {{earthshaker:dc}}. On a failed save, the creature's concentration is broken. At the end of your turn, each creature on the ground in the area must make a Dexterity saving throw with the same DC as the previous one. On a failed save, the creature is knocked prone. You have advantage on this saving throw.<br/>
+        At the beginning of each of your subsequent turns, you may use your bonus action to continue the effects of the earthquake until the beginning of your next turn, for a maximum duration of 1 minute.
+      </description>
+    </sheet>
+    <rules>
+      <stat name="earthshaker:dc" value="8" />
+      <stat name="earthshaker:dc" value="strength:modifier" />
+      <stat name="earthshaker:dc" value="proficiency" />
+    </rules>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
@@ -61,19 +61,6 @@
     </rules>
   </element>
 
-  <element name="Thunderous Shot" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT">
-    <sheet>
-      <description usage="1/Short Rest">
-        When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is {{mighty marksman:dc}}.
-      </description>
-    </sheet>
-    <rules>
-      <stat name="mighty marksman:dc" value="8" />
-      <stat name="mighty marksman:dc" value="strength:modifier" />
-      <stat name="mighty marksman:dc" value="proficiency" />
-    </rules>
-  </element>
-
   <element name="Herculean Rage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE">
     <description>
       <p>Starting at 10th level, your rages take on legendary qualities and grow more powerful the longer they endure. At the beginning of each of your turns, if you are already raging, your rage damage bonus increases by +1, up to a maximum of your Strength modifier. Additionally, while raging, you are immune to poison damage and you cannot be frightened.</p>
@@ -102,6 +89,20 @@
       <stat name="earthshaker:dc" value="8" />
       <stat name="earthshaker:dc" value="strength:modifier" />
       <stat name="earthshaker:dc" value="proficiency" />
+    </rules>
+  </element>
+
+  <!-- subfeatures -->
+  <element name="Thunderous Shot" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_THUNDEROUS_SHOT">
+    <sheet>
+      <description usage="1/Short Rest">
+        When you make a ranged attack, you may choose to add the effect of <i>thunderwave</i> to the projectile, centered on the location that the projectile hits. The DC for this effect is {{mighty marksman:dc}}.
+      </description>
+    </sheet>
+    <rules>
+      <stat name="mighty marksman:dc" value="8" />
+      <stat name="mighty marksman:dc" value="strength:modifier" />
+      <stat name="mighty marksman:dc" value="proficiency" />
     </rules>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-barbarian-herculean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-barbarian-herculean.xml" />
 		</update>
@@ -18,7 +17,7 @@
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_HERCULEAN_RAGE" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARBARIAN_HERCULEAN_EARTHSHAKER" />
     </description>
-    <sheet display="true">
+    <sheet display="false">
       <description>
         Some individuals are born with seemingly impossible strength.</description>
     </sheet>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
@@ -91,6 +91,28 @@
     </rules>
   </element>
 
+  <element name="Armored Poet" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET">
+    <description>
+      <p>Starting at 6th level, you gain proficiency with medium armor, so that you can get close to the fighting while composing your poem. Additionally, if you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</p>
+    </description>
+    <sheet>
+      <description>If you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</description>
+    </sheet>
+    <rules>
+      <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" />
+    </rules>
+  </element>
+
+  <element name="Protective Epithets" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS">
+    <description>
+      <p>Starting at 14th level, the lyrical epithets that you've selected for your allies take on magical properties, protecting them from death. Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</p>
+    </description>
+    <sheet>
+      <description>Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</description>
+    </sheet>
+  </element>
+
+  <!-- verse count selection -->
   <element name="0-5 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_05">
 		<supports>Verse Count</supports>
 		<description />
@@ -261,8 +283,8 @@
 		</rules>
 	</element>
 
+  <!-- Bardic Inspiration improvements -->
   <element name="Improved Rolls" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS">
-		<supports>06-11 verses,12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
 		<description />
 		<sheet>
       <description>Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value, then the result is equal to the minimum value.</description>
@@ -270,81 +292,54 @@
 	</element>
 
   <element name="Additional Effects" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS">
-		<supports>12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
 		<description />
 		<sheet>
-      <description>When you give someone Bardic Inspiration, choose one of the (Bardic Inspiration) effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</description>
+      <description>When you give someone Bardic Inspiration, choose one of the Inspirational Verses effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</description>
     </sheet>
 	</element>
 
   <element name="Epic Courage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE">
-    <supports>12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
     <description>
       <p>You gain advantage on saving throws against effects that would frighten you.</p>
     </description>
 		<sheet>
-      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on saving throws against effects that would frighten you.</description>
+      <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on saving throws against effects that would frighten you.</description>
     </sheet>
   </element>
 
   <element name="Epic Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT">
-    <supports>24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
     <description>
       <p>You cannot be surprised, and your passive Perception increases by +5.</p>
     </description>
 		<sheet>
-      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you cannot be surprised, and your passive Perception increases by +5.</description>
+      <description usage="Inspirational Verses">While you have Bardic Inspiration, you cannot be surprised, and your passive Perception increases by +5.</description>
     </sheet>
   </element>
 
   <element name="Epic Determination" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION">
-    <supports>36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
     <description>
       <p>You gain advantage on death saving throws.</p>
     </description>
 		<sheet>
-      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on death saving throws.</description>
+      <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on death saving throws.</description>
     </sheet>
   </element>
 
   <element name="Epic Reflexes" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES">
-    <supports>48-53 verses,54-59 verses,60+ verses</supports>
     <description>
       <p>You gain advantage on saving throws against spells that affect multiple targets.</p>
     </description>
 		<sheet>
-      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on saving throws against spells that affect multiple targets.</description>
+      <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on saving throws against spells that affect multiple targets.</description>
     </sheet>
   </element>
 
   <element name="Epic Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_RESISTANCE">
-    <supports>60+ verses</supports>
     <description>
       <p>You gain resistance to one damage type (Bard’s choice).</p>
     </description>
 		<sheet>
-      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain resistance to one damage type (Bard’s choice).</description>
-    </sheet>
-  </element>
-
-  <element name="Armored Poet" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET">
-    <description>
-      <p>Starting at 6th level, you gain proficiency with medium armor, so that you can get close to the fighting while composing your poem. Additionally, if you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</p>
-    </description>
-    <sheet>
-      <description>If you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</description>
-    </sheet>
-    <rules>
-      <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" />
-    </rules>
-  </element>
-
-  <element name="Protective Epithets" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS">
-    <description>
-      <p>Starting at 14th level, the lyrical epithets that you've selected for your allies take on magical properties, protecting them from death. Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</p>
-    </description>
-    <sheet>
-      <description>Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</description>
+      <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain resistance to one damage type (Bard’s choice).</description>
     </sheet>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
@@ -24,72 +24,63 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS" level="14" />
     </rules>
   </element>
-
   <element name="Epic Verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_EPIC_VERSES">
     <description>
       <p>Starting when you join the College of Epic Poetry at 3rd level, you begin composing your epic poem. When certain significant events occur during your travels or during combat, you may use your reaction to compose a new epic verse. Significant events are defined as any of the following things happening to you or one of your allies by chance (e.g. your party cannot deliberately force them to happen by repetition). You must be able to see or hear the event happen.</p>
-      <p>
-        <b>Comedy:</b> Someone rolls a natural 1 on an attack or saving throw.<br/>
-        <b>Hubris:</b> Someone rolls a natural 20 on an attack or saving throw.<br/>
-        <b>Irony:</b> Someone fails a saving throw after adding a Bardic Inspiration die.<br/>
-        <b>Tragedy:</b> Someone is reduced to zero hit points by an enemy.
-      </p>
+      <ul>
+        <li><b>Comedy:</b> Someone rolls a natural 1 on an attack or saving throw.</li>
+        <li><b>Hubris:</b> Someone rolls a natural 20 on an attack or saving throw.</li>
+        <li><b>Irony:</b> Someone fails a saving throw after adding a Bardic Inspiration die.</li>
+        <li><b>Tragedy:</b> Someone is reduced to zero hit points by an enemy.</li>
+      </ul>
       <p>Additionally, any particularly exciting event that seems to warrant inclusion in your poem is eligible as long as the GM approves—but don’t push it.</p>
       <p class="indent">Each time you compose a new epic verse, you must declare that you are doing so. If the GM approves, then you may add 1 verse to your poem. You may also want to write down what happened and why, so that you can enjoy reading it later, but this is not required. Your poem increases in rank as the number of verses grows.</p>
     </description>
     <sheet action="Reaction">
-      <description level="3">When someone rolls a natural 1 or 20 on an attack or saving throw, fails a saving throw after adding a Bardic Inspiration die or is reduced to 0 hit points by an enemy, compose one verse. Additionally, any particularly exciting event that seems to warrant inclusion in your poem is eligible as long as the GM approves.</description>
+      <description>When someone rolls a natural 1 or 20 on an attack or saving throw, fails a saving throw after adding a Bardic Inspiration die or is reduced to 0 hit points by an enemy, compose one verse. Additionally, any particularly exciting event that seems to warrant inclusion in your poem is eligible as long as the GM approves.</description>
     </sheet>
   </element>
-
   <element name="Inspirational Verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_INSPIRATIONAL_VERSES">
     <description>
       <p>Starting at 3rd level, when you give someone Bardic Inspiration, you recite a portion of your epic poem, which improves the effect of the dice based upon the rank of your poem.</p>
-      <p class="indent">
-        <b>Improved Rolls.</b> Your Bardic Inspiration dice have a minimum result value based on the number of verses that you’ve collected. Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value for your poem rank, then the result is equal to the minimum value as determined by your poem rank.
-      </p>
-      <p class="indent">
-        <b>Additional Effects.</b> Your Bardic Inspiration dice have additional effects based on the number of verses that you’ve collected. When you give someone Bardic Inspiration, choose one of the following effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.
-      </p>
-      <p class="indent">
-        <b>Epic Courage:</b> You gain advantage on saving throws against effects that would frighten you.
-      </p>
-      <p class="indent">
-        <b>Epic Determination:</b> You gain advantage on death saving throws.
-      </p>
-      <p class="indent">
-        <b>Epic Foresight:</b> You cannot be surprised, and your passive Perception increases by +5.
-      </p>
-      <p class="indent">
-        <b>Epic Reflexes:</b> You gain advantage on saving throws against spells that affect multiple targets.
-      </p>
-      <p class="indent">
-        <b>Epic Resistance:</b> You gain resistance to one damage type (Bard’s choice).
-      </p>
-      <table>
-		<thead>
-			<tr><th>Poem Rank</th><th>Required Verse Count</th><th>Bardic Inspiration Improvement</th></tr>
-		</thead>
-		<tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+      <p class="indent"><b>Improved Rolls.</b> Your Bardic Inspiration dice have a minimum result value based on the number of verses that you’ve collected. Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value for your poem rank, then the result is equal to the minimum value as determined by your poem rank.</p>
+      <p class="indent"><b>Additional Effects.</b> Your Bardic Inspiration dice have additional effects based on the number of verses that you’ve collected. When you give someone Bardic Inspiration, choose one of the following effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</p>
+      <p class="indent"><b>Epic Courage:</b> You gain advantage on saving throws against effects that would frighten you.</p>
+      <p class="indent"><b>Epic Determination:</b> You gain advantage on death saving throws.</p>
+      <p class="indent"><b>Epic Foresight:</b> You cannot be surprised, and your passive Perception increases by +5.</p>
+      <p class="indent"><b>Epic Reflexes:</b> You gain advantage on saving throws against spells that affect multiple targets.</p>
+      <p class="indent"><b>Epic Resistance:</b> You gain resistance to one damage type (Bard’s choice).</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
         <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
         <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
-		<tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
         <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
         <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
         <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
         <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
         <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
         <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
-	  </table>
+      </table>
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
     <sheet>
-      <description>Verse count:</description>
+      <description>Your poem rank is {{epic poetry:poem rank}} and your Bardic Inspiration dice have a minimum result of {{epic poetry:inspiration minimum value}}.
+      When you give someone Bardic Inspiration, they gain one benefit as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</description>
     </sheet>
     <rules>
-      <select type="Archetype Feature" name="Verse Count" supports="Verse Count" />
+      <select type="Archetype Feature" name="Poem Rank" supports="Inspirational Verses Poem Rank" optional="true"/>      
+      <stat name="epic poetry:poem rank" value="0" />
+      <stat name="epic poetry:inspiration minimum value" value="1" bonus="base" />      
     </rules>
   </element>
-
   <element name="Armored Poet" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET">
     <description>
       <p>Starting at 6th level, you gain proficiency with medium armor, so that you can get close to the fighting while composing your poem. Additionally, if you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</p>
@@ -101,7 +92,6 @@
       <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" />
     </rules>
   </element>
-
   <element name="Protective Epithets" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS">
     <description>
       <p>Starting at 14th level, the lyrical epithets that you've selected for your allies take on magical properties, protecting them from death. Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</p>
@@ -111,193 +101,354 @@
     </sheet>
   </element>
 
-  <!-- verse count selection -->
-  <element name="0-5 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_05">
-		<supports>Verse Count</supports>
-		<description />
-		<sheet display="false" />
-	</element>
-
-  <element name="06-11 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_611">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 2</p>
+  <element name="Poem Rank 1" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_1">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td class="col-20">Poem Rank</td><td class="col-20">Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 2</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <stat name="epic poetry:poem rank" value="1" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="2" bonus="base" />
     </rules>
 	</element>
-
-  <element name="12-17 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_1217">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 2</p>
+  <element name="Poem Rank 2" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_2">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 2</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
-			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
-		</rules>
+      <stat name="epic poetry:poem rank" value="2" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="2" bonus="base" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+    </rules>
 	</element>
-
-  <element name="18-23 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_1823">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 3</p>
+  <element name="Poem Rank 3" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_3">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 3</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
-			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
-		</rules>
+      <stat name="epic poetry:poem rank" value="3" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="3" bonus="base" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+    </rules>
 	</element>
-
-  <element name="24-29 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_2429">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 3</p>
+  <element name="Poem Rank 4" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_4">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 3</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="4" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="3" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="30-35 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_3035">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 4</p>
+  <element name="Poem Rank 5" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_5">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 4</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="5" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="4" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="36-41 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_3641">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 4</p>
+  <element name="Poem Rank 6" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_6">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 4</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="6" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="4" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="42-47 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_4247">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 5</p>
+  <element name="Poem Rank 7" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_7">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 5</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="7" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="5" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="48-53 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_4853">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 5</p>
+  <element name="Poem Rank 8" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_8">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 5</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="8" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="5" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="54-59 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_5459">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 6</p>
+  <element name="Poem Rank 9" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_9">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 6</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="9" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="6" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
-		</rules>
+    </rules>
 	</element>
-
-  <element name="60+ verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_60">
-		<supports>Verse Count</supports>
-		<description>
-      <p>Bardic Inspiration minimum value: 6</p>
+  <element name="Poem Rank 10" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_POEM_RANK_10">
+    <compendium display="false"/>
+		<supports>Inspirational Verses Poem Rank</supports>
+    <description>
+      <p>Your poem increases in rank as the number of verses grows.</p>
+      <h5 class="caption">EPIC POEM RANKS AND EFFECTS</h5>
+      <table class="class-features">
+        <thead>
+          <tr><td>Poem Rank</td><td>Required Verse Count</td><td>Bardic Inspiration Improvement</td></tr>
+        </thead>
+        <tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+        <tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+      </table>      
+      <div class="sidebar">
+        <h5>VERSE COUNTS &amp; PARTY SIZE</h5>
+        <p>These verse counts are based on a party size of six. If you have less than six members in your party, then the required verse counts are reduced. Multiply your party size by the poem rank to determine the required verse count. For example, if you have 3 party members, then your required verse count for rank 6 is equal to 18 (3 x 6)</p>
+      </div>
     </description>
-		<sheet>
-      <description>Bardic Inspiration minimum value: 6</description>
-    </sheet>
+    <sheet display="false" />
     <rules>
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+      <stat name="epic poetry:poem rank" value="10" bonus="base" />
+      <stat name="epic poetry:inspiration minimum value" value="6" bonus="base" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_RESISTANCE" />
-		</rules>
+    </rules>
 	</element>
-
-  <!-- Bardic Inspiration improvements -->
-  <element name="Improved Rolls" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS">
-		<description />
-		<sheet>
-      <description>Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value, then the result is equal to the minimum value.</description>
-    </sheet>
-	</element>
-
-  <element name="Additional Effects" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS">
-		<description />
-		<sheet>
-      <description>When you give someone Bardic Inspiration, choose one of the Inspirational Verses effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</description>
-    </sheet>
-	</element>
-
+  
   <element name="Epic Courage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE">
+    <compendium display="false"/>
     <description>
       <p>You gain advantage on saving throws against effects that would frighten you.</p>
     </description>
@@ -305,8 +456,8 @@
       <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on saving throws against effects that would frighten you.</description>
     </sheet>
   </element>
-
   <element name="Epic Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT">
+    <compendium display="false"/>
     <description>
       <p>You cannot be surprised, and your passive Perception increases by +5.</p>
     </description>
@@ -314,8 +465,8 @@
       <description usage="Inspirational Verses">While you have Bardic Inspiration, you cannot be surprised, and your passive Perception increases by +5.</description>
     </sheet>
   </element>
-
   <element name="Epic Determination" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION">
+    <compendium display="false"/>
     <description>
       <p>You gain advantage on death saving throws.</p>
     </description>
@@ -323,8 +474,8 @@
       <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on death saving throws.</description>
     </sheet>
   </element>
-
   <element name="Epic Reflexes" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES">
+    <compendium display="false"/>
     <description>
       <p>You gain advantage on saving throws against spells that affect multiple targets.</p>
     </description>
@@ -332,13 +483,27 @@
       <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain advantage on saving throws against spells that affect multiple targets.</description>
     </sheet>
   </element>
-
   <element name="Epic Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_RESISTANCE">
+    <compendium display="false"/>
     <description>
       <p>You gain resistance to one damage type (Bard’s choice).</p>
     </description>
 		<sheet>
       <description usage="Inspirational Verses">While you have Bardic Inspiration, you gain resistance to one damage type (Bard’s choice).</description>
     </sheet>
+  </element>
+
+  <!-- simple stackable item to help keep track of the number of verses you've composed -->
+  <element name="Epic Poem Verse" type="Item" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ITEM_POEM_VERSE">
+    <description>
+      <p>Starting when you join the College of Epic Poetry, you begin composing your epic poem. When certain significant events occur during your travels or during combat, you may compose a new epic verse.</p>
+    </description>
+    <setters>
+      <set name="keywords">epic poetry, bard college, inspirational verses</set>
+      <set name="category">Adventuring Gear</set>
+      <set name="cost" currency="gp">0</set>
+      <set name="weight" lb="0">0 lb.</set>
+      <set name="stackable">true</set>
+    </setters>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-bard-epicpoetry.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml" />
+		</update>
+	</info>
+  <element name="College of Epic Poetry" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_BARD_COLLEGE_OF_EPIC_POETRY">
+    <supports>Bard College</supports>
+    <description>
+      <p>Bards who study the College of Epic Poetry are devoted to the creation of a singular masterpiece in the tradition of the epic poets. All the greatest stories in history were originally captured and recreated for audiences as masterful works of poetry. These stories were passed down for centuries in an oral tradition, and eventually, they were recorded on papyrus scrolls and stored in great libraries.</p>
+      <p class="indent">Those who wish to record their own epic poems spend their early years studying philosophy, aesthetics, and music, so that they have the necessary language to capture the splendor of great deeds. However, an epic poet cannot spend all their life in the Academy. Eventually, they must seek out great conflicts, for great conflicts produce great heroes, and great heroes produce great deeds.</p>
+      <p class="indent">As such, you have prepared yourself for a life of turmoil, chasing after warriors who brave impossible odds. You have learned to transcribe events faithfully, even in the chaos of battle. You know that if your quill slips at a pivotal moment, the beauty of that instant may be forever lost to history.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_EPIC_VERSES" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_INSPIRATIONAL_VERSES" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS" />
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_EPIC_VERSES" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_INSPIRATIONAL_VERSES" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET" level="6" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS" level="14" />
+    </rules>
+  </element>
+
+  <element name="Epic Verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_EPIC_VERSES">
+    <description>
+      <p>Starting when you join the College of Epic Poetry at 3rd level, you begin composing your epic poem. When certain significant events occur during your travels or during combat, you may use your reaction to compose a new epic verse. Significant events are defined as any of the following things happening to you or one of your allies by chance (e.g. your party cannot deliberately force them to happen by repetition). You must be able to see or hear the event happen.</p>
+      <p>
+        <b>Comedy:</b> Someone rolls a natural 1 on an attack or saving throw.<br/>
+        <b>Hubris:</b> Someone rolls a natural 20 on an attack or saving throw.<br/>
+        <b>Irony:</b> Someone fails a saving throw after adding a Bardic Inspiration die.<br/>
+        <b>Tragedy:</b> Someone is reduced to zero hit points by an enemy.
+      </p>
+      <p>Additionally, any particularly exciting event that seems to warrant inclusion in your poem is eligible as long as the GM approves—but don’t push it.</p>
+      <p class="indent">Each time you compose a new epic verse, you must declare that you are doing so. If the GM approves, then you may add 1 verse to your poem. You may also want to write down what happened and why, so that you can enjoy reading it later, but this is not required. Your poem increases in rank as the number of verses grows.</p>
+    </description>
+    <sheet action="Reaction">
+      <description level="3">When someone rolls a natural 1 or 20 on an attack or saving throw, fails a saving throw after adding a Bardic Inspiration die or is reduced to 0 hit points by an enemy, compose one verse. Additionally, any particularly exciting event that seems to warrant inclusion in your poem is eligible as long as the GM approves.</description>
+    </sheet>
+  </element>
+
+  <element name="Inspirational Verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_INSPIRATIONAL_VERSES">
+    <description>
+      <p>Starting at 3rd level, when you give someone Bardic Inspiration, you recite a portion of your epic poem, which improves the effect of the dice based upon the rank of your poem.</p>
+      <p class="indent">
+        <b>Improved Rolls.</b> Your Bardic Inspiration dice have a minimum result value based on the number of verses that you’ve collected. Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value for your poem rank, then the result is equal to the minimum value as determined by your poem rank.
+      </p>
+      <p class="indent">
+        <b>Additional Effects.</b> Your Bardic Inspiration dice have additional effects based on the number of verses that you’ve collected. When you give someone Bardic Inspiration, choose one of the following effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.
+      </p>
+      <p class="indent">
+        <b>Epic Courage:</b> You gain advantage on saving throws against effects that would frighten you.
+      </p>
+      <p class="indent">
+        <b>Epic Determination:</b> You gain advantage on death saving throws.
+      </p>
+      <p class="indent">
+        <b>Epic Foresight:</b> You cannot be surprised, and your passive Perception increases by +5.
+      </p>
+      <p class="indent">
+        <b>Epic Reflexes:</b> You gain advantage on saving throws against spells that affect multiple targets.
+      </p>
+      <p class="indent">
+        <b>Epic Resistance:</b> You gain resistance to one damage type (Bard’s choice).
+      </p>
+      <table>
+		<thead>
+			<tr><th>Poem Rank</th><th>Required Verse Count</th><th>Bardic Inspiration Improvement</th></tr>
+		</thead>
+		<tr><td>1</td><td>6</td><td>Minimum Value = 2</td></tr>
+        <tr><td>2</td><td>12</td><td>Epic Courage</td></tr>
+        <tr><td>3</td><td>18</td><td>Minimum Value = 3</td></tr>
+		<tr><td>4</td><td>24</td><td>Epic Foresight</td></tr>
+        <tr><td>5</td><td>30</td><td>Minimum Value = 4</td></tr>
+        <tr><td>6</td><td>36</td><td>Epic Determination</td></tr>
+        <tr><td>7</td><td>42</td><td>Minimum Value = 5</td></tr>
+        <tr><td>8</td><td>48</td><td>Epic Reflexes</td></tr>
+        <tr><td>9</td><td>54</td><td>Minimum Value = 6</td></tr>
+        <tr><td>10</td><td>60</td><td>Epic Resistance</td></tr>
+	  </table>
+    </description>
+    <sheet>
+      <description>Verse count:</description>
+    </sheet>
+    <rules>
+      <select type="Archetype Feature" name="Verse Count" supports="Verse Count" />
+    </rules>
+  </element>
+
+  <element name="0-5 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_05">
+		<supports>Verse Count</supports>
+		<description />
+		<sheet display="false" />
+	</element>
+
+  <element name="06-11 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_611">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 2</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 2</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+    </rules>
+	</element>
+
+  <element name="12-17 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_1217">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 2</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 2</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+		</rules>
+	</element>
+
+  <element name="18-23 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_1823">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 3</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 3</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+		</rules>
+	</element>
+
+  <element name="24-29 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_2429">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 3</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 3</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+		</rules>
+	</element>
+
+  <element name="30-35 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_3035">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 4</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 4</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+		</rules>
+	</element>
+
+  <element name="36-41 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_3641">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 4</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 4</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
+		</rules>
+	</element>
+
+  <element name="42-47 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_4247">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 5</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 5</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
+		</rules>
+	</element>
+
+  <element name="48-53 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_4853">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 5</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 5</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
+		</rules>
+	</element>
+
+  <element name="54-59 verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_5459">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 6</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 6</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
+		</rules>
+	</element>
+
+  <element name="60+ verses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_60">
+		<supports>Verse Count</supports>
+		<description>
+      <p>Bardic Inspiration minimum value: 6</p>
+    </description>
+		<sheet>
+      <description>Bardic Inspiration minimum value: 6</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_RESISTANCE" />
+		</rules>
+	</element>
+
+  <element name="Improved Rolls" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_IMPROVED_ROLLS">
+		<supports>06-11 verses,12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
+		<description />
+		<sheet>
+      <description>Whenever someone rolls one of your Bardic Inspiration dice, if they roll less than the minimum value, then the result is equal to the minimum value.</description>
+    </sheet>
+	</element>
+
+  <element name="Additional Effects" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_ADDITIONAL_EFFECTS">
+		<supports>12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
+		<description />
+		<sheet>
+      <description>When you give someone Bardic Inspiration, choose one of the (Bardic Inspiration) effects that you have unlocked. They gain the benefit of this effect as long as they have your Bardic Inspiration die. The effect is lost when they roll the die.</description>
+    </sheet>
+	</element>
+
+  <element name="Epic Courage" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_COURAGE">
+    <supports>12-17 verses,18-23 verses,24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
+    <description>
+      <p>You gain advantage on saving throws against effects that would frighten you.</p>
+    </description>
+		<sheet>
+      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on saving throws against effects that would frighten you.</description>
+    </sheet>
+  </element>
+
+  <element name="Epic Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_FORESIGHT">
+    <supports>24-29 verses,30-35 verses,36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
+    <description>
+      <p>You cannot be surprised, and your passive Perception increases by +5.</p>
+    </description>
+		<sheet>
+      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you cannot be surprised, and your passive Perception increases by +5.</description>
+    </sheet>
+  </element>
+
+  <element name="Epic Determination" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_DETERMINATION">
+    <supports>36-41 verses,42-47 verses,48-53 verses,54-59 verses,60+ verses</supports>
+    <description>
+      <p>You gain advantage on death saving throws.</p>
+    </description>
+		<sheet>
+      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on death saving throws.</description>
+    </sheet>
+  </element>
+
+  <element name="Epic Reflexes" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_REFLEXES">
+    <supports>48-53 verses,54-59 verses,60+ verses</supports>
+    <description>
+      <p>You gain advantage on saving throws against spells that affect multiple targets.</p>
+    </description>
+		<sheet>
+      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain advantage on saving throws against spells that affect multiple targets.</description>
+    </sheet>
+  </element>
+
+  <element name="Epic Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_EPIC_POETRY_VERSES_EPIC_RESISTANCE">
+    <supports>60+ verses</supports>
+    <description>
+      <p>You gain resistance to one damage type (Bard’s choice).</p>
+    </description>
+		<sheet>
+      <description usage="Bardic Inspiration">While you have Bardic Inspiration, you gain resistance to one damage type (Bard’s choice).</description>
+    </sheet>
+  </element>
+
+  <element name="Armored Poet" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_ARMORED_POET">
+    <description>
+      <p>Starting at 6th level, you gain proficiency with medium armor, so that you can get close to the fighting while composing your poem. Additionally, if you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</p>
+    </description>
+    <sheet>
+      <description>If you are within 5 feet of an ally when you compose an epic verse about them, then you regain one expended Bardic Inspiration die.</description>
+    </sheet>
+    <rules>
+      <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_MEDIUM_ARMOR" />
+    </rules>
+  </element>
+
+  <element name="Protective Epithets" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_BARD_EPIC_POETRY_PROTECTIVE_EPITHETS">
+    <description>
+      <p>Starting at 14th level, the lyrical epithets that you've selected for your allies take on magical properties, protecting them from death. Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</p>
+    </description>
+    <sheet>
+      <description>Whenever a character with your Bardic Inspiration die would be reduced to 0 hit points, they may choose to roll their Bardic Inspiration die and be reduced to that number of hit points instead. The Bardic Inspiration die is then lost.</description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-bard-epicpoetry.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-bard-epicpoetry.xml" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
@@ -9,7 +9,7 @@
     <supports>Divine Domain</supports>
     <description>
       <p>The Prophecy domain focuses on foretelling danger and preventing harmful outcomes. Clerics of this domain are also known as “oracles.” Oracles pay special attention to dreams, intuitive thoughts, and hallucinatory visions. They are widely believed to be capable of predicting the future, though their visions are often misinterpreted. They live by the phrase, “know thyself.”</p>
-      <p>Oracles often carry special varieties of incense and holy water with them. The holy water may be boiled to produce vapors, which the oracle inhales in order to enter a trance-like state. During such a trance, the oracle thrashes and wails as they experience flashes of divine insight. They often employ scribes to write down their words, so that they may be recalled later.</p>
+      <p class="indent">Oracles often carry special varieties of incense and holy water with them. The holy water may be boiled to produce vapors, which the oracle inhales in order to enter a trance-like state. During such a trance, the oracle thrashes and wails as they experience flashes of divine insight. They often employ scribes to write down their words, so that they may be recalled later.</p>
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_MINDFUL_SENSES" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_BLESSING_OF_FORESIGHT" />
@@ -31,11 +31,10 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT" level="17"/>
     </rules>
   </element>
-  
   <element name="Domain Spells" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS">
     <description>
       <p>You gain domain spells at the cleric levels listed in the Forge Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
-      <h5>Forge Domain Spells</h5>
+      <h5 class="caption">FORGE DOMAIN SPELLS</h5>
       <table>
         <thead>
           <tr><td>Cleric Level</td><td>Spells</td></tr>
@@ -47,9 +46,7 @@
         <tr><td>9th</td><td><em>dream, scrying</em></td></tr>
       </table>
     </description>
-    <sheet display="false">
-      <description></description>
-    </sheet>
+    <sheet display="false" />
     <rules>
       <grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" level="1" spellcasting="Cleric" prepared="true" />
       <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" level="1" spellcasting="Cleric" prepared="true" />
@@ -63,7 +60,6 @@
       <grant type="Spell" id="ID_PHB_SPELL_SCRYING" level="9" spellcasting="Cleric" prepared="true" />
     </rules>
   </element> 
-
   <element name="Mindful Senses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_MINDFUL_SENSES">
     <description>
       <p>When you choose this domain at 1st level, you gain the message cantrip if you don’t already know it. Additionally, you gain proficiency in the Perception skill.</p>
@@ -76,20 +72,18 @@
       <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERCEPTION" />
     </rules>
   </element> 
-
   <element name="Blessing of Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_BLESSING_OF_FORESIGHT">
     <description>
       <p>Starting at 1st level, you use your divination spells to protect your allies from future events. Whenever you cast a divination spell of 1st level or higher, choose one creature you can see. That creature gains temporary hit points equal to your Wisdom modifier + your cleric level.</p>
     </description>
     <sheet>
-      <description>Whenever you cast a divination spell of 1st level or higher, choose one creature you can see. That creature gains temporary hit points equal to {{blessing of foresight:hp}}.</description>
+      <description>Whenever you cast a divination spell of 1st level or higher, choose one creature you can see. That creature gains {{blessing of foresight:hp}} temporary hp.</description>
     </sheet>
     <rules>
       <stat name="blessing of foresight:hp" value="wisdom:modifier" />
       <stat name="blessing of foresight:hp" value="level:cleric" />
     </rules>
-  </element> 
-
+  </element>
   <element name="Channel Divinity: Prophetic Trance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_CD_PROPHETIC_TRANCE">
     <description>
       <p>Starting at 2nd level, you can use your Channel Divinity to enter a prophetic trance. As an action, you inhale hallucinatory vapors and enter a trance-like state for 10 minutes. Roll two d20s and record the numbers rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with one of these prophecy rolls. You must choose to do so before the roll is made. Each prophecy roll can be used only once. You lose the prophecy rolls when your trance ends.</p>
@@ -97,8 +91,7 @@
     <sheet alt="Prophetic Trance" usage="Channel Divinity">
       <description>As an action, you inhale hallucinatory vapors and enter a trance-like state for 10 minutes. Roll two d20s and record the numbers rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with one of these prophecy rolls. You must choose to do so before the roll is made. Each prophecy roll can be used only once. You lose the prophecy rolls when your trance ends.</description>
     </sheet>
-  </element> 
-
+  </element>
   <element name="Visions of Danger" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_VISIONS_OF_DANGER">
     <description>
       <p>Starting at 6th level, you experience flashes of foresight that reveal to you when your allies will be harmed, allowing you to react with uncanny speed. When you ready a spell that restores hit points, it does not require or break concentration. Additionally, when one of your allies takes damage or fails a saving throw, you may use your reaction to move up to your speed and cast a beneficial spell that only targets your imperiled ally. The casting time of the spell must be a reaction, action, or bonus action. You may use this feature twice, and you regain any expended uses when you finish a short or long rest.</p>
@@ -107,36 +100,25 @@
       <description usage="2/Short Rest" >When you ready a spell that restores hit points, it does not require or break concentration. Additionally, when one of your allies takes damage or fails a saving throw, you may use your reaction to move up to your speed and cast a beneficial spell that only targets your imperiled ally. The casting time of the spell must be a reaction, action, or bonus action.</description>
     </sheet>
   </element> 
-
   <element name="Healing Vapors" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS">
     <description>
       <p>Starting at 8th level, your healing spells are accompanied by a mist of restorative vapors. Whenever you use a spell of 1st level or higher to restore hit points to a creature, the creature regains additional hit points equal to your Wisdom modifier.</p>
       <p class="indent">Additionally, when you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of <i>fog cloud</i> at the location of one of your targets. You must complete a long rest before you can create another fog cloud with this feature.</p>
     </description>
     <sheet>
-      <description>Whenever you use a spell of 1st level or higher to restore hit points to a creature, the creature regains additional hit points equal to {{healing vapors:hp}}.</description>
+      <description>Whenever you use a spell of 1st level or higher to restore hp to a creature, the creature regains {{healing vapors:hp}} additional hp.
+      Additionally, when you cast a spell of 1st level or higher that restores hp, you may choose to add the effect of fog cloud at the location of one of your targets. You must complete a long rest before you can create another fog cloud with this feature.</description>
     </sheet>
     <rules>
       <stat name="healing vapors:hp" value="wisdom:modifier" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG" />
     </rules>
   </element>
-
   <element name="Perfect Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT">
     <description>
       <p>Starting at 17th level, your prophetic powers are nearly infallible. When you enter a prophetic trance with Channel Divinity, you may choose to replace the result of either d20 prophecy roll with any number between 1 and 19 of your choice. Additionally, while you are in the trance, you gain darkvision out to a range of 60 feet, and you can see invisible creatures and objectives within 10 feet of you that are within line of sight.</p>
     </description>
     <sheet>
       <description>When you enter a prophetic trance with Channel Divinity, you may choose to replace the result of either d20 prophecy roll with any number between 1 and 19 of your choice. Additionally, while you are in the trance, you gain darkvision out to a range of 60 feet, and you can see invisible creatures and objectives within 10 feet of you that are within line of sight.</description>
-    </sheet>
-  </element> 
-
-  <!-- subfeatures -->
-  <element name="Healing Vapors: Fog Cloud" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG">
-    <sheet>
-      <description usage="1/Long Rest">
-        When you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of fog cloud at the location of one of your targets.
-      </description>
     </sheet>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-cleric-prophecy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml" />
+		</update>
+	</info>
+  <element name="Prophecy Domain" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_CLERIC_PROPHECY_DOMAIN">
+    <supports>Divine Domain</supports>
+    <description>
+      <p>The Prophecy domain focuses on foretelling danger and preventing harmful outcomes. Clerics of this domain are also known as “oracles.” Oracles pay special attention to dreams, intuitive thoughts, and hallucinatory visions. They are widely believed to be capable of predicting the future, though their visions are often misinterpreted. They live by the phrase, “know thyself.”</p>
+      <p>Oracles often carry special varieties of incense and holy water with them. The holy water may be boiled to produce vapors, which the oracle inhales in order to enter a trance-like state. During such a trance, the oracle thrashes and wails as they experience flashes of divine insight. They often employ scribes to write down their words, so that they may be recalled later.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_MINDFUL_SENSES" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_BLESSING_OF_FORESIGHT" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_CD_PROPHETIC_TRANCE" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_VISIONS_OF_DANGER" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT" />
+    </description>
+    <sheet>
+      <description>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords.</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS" level="1"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_MINDFUL_SENSES" level="1"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_BLESSING_OF_FORESIGHT" level="1"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_CD_PROPHETIC_TRANCE" level="2"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_VISIONS_OF_DANGER" level="6"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS" level="8"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT" level="17"/>
+    </rules>
+  </element>
+  
+  <element name="Domain Spells" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS">
+    <description>
+      <p>You gain domain spells at the cleric levels listed in the Forge Domain Spells table. See the Divine Domain class feature for how domain spells work.</p>
+      <h5>Forge Domain Spells</h5>
+      <table>
+        <thead>
+          <tr><td>Cleric Level</td><td>Spells</td></tr>
+        </thead>
+        <tr><td>1st</td><td><em>detect magic, identify</em></td></tr>
+        <tr><td>3rd</td><td><em>augury, locate object</em></td></tr>
+        <tr><td>5th</td><td><em>beacon of hope, clairvoyance</em></td></tr>
+        <tr><td>7th</td><td><em>death ward, divination</em></td></tr> 
+        <tr><td>9th</td><td><em>dream, scrying</em></td></tr>
+      </table>
+    </description>
+    <sheet display="false">
+      <description></description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" level="1" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" level="1" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_AUGURY" level="3" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_LOCATE_OBJECT" level="3" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_BEACON_OF_HOPE" level="5" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_CLAIRVOYANCE" level="5" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_DEATH_WARD" level="7" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_DIVINATION" level="7" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_DREAM" level="9" spellcasting="Cleric" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_SCRYING" level="9" spellcasting="Cleric" prepared="true" />
+    </rules>
+  </element> 
+
+  <element name="Mindful Senses" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_MINDFUL_SENSES">
+    <description>
+      <p>When you choose this domain at 1st level, you gain the message cantrip if you don’t already know it. Additionally, you gain proficiency in the Perception skill.</p>
+    </description>
+    <sheet display="false">
+      <description>You learn the cantrip message and gain proficiency in the Perception skill.</description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_MESSAGE" />
+      <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERCEPTION" />
+    </rules>
+  </element> 
+
+  <element name="Blessing of Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_BLESSING_OF_FORESIGHT">
+    <description>
+      <p>Starting at 1st level, you use your divination spells to protect your allies from future events. Whenever you cast a divination spell of 1st level or higher, choose one creature you can see. That creature gains temporary hit points equal to your Wisdom modifier + your cleric level.</p>
+    </description>
+    <sheet>
+      <description>Whenever you cast a divination spell of 1st level or higher, choose one creature you can see. That creature gains temporary hit points equal to {{blessing of foresight:hp}}.</description>
+    </sheet>
+    <rules>
+      <stat name="blessing of foresight:hp" value="wisdom:modifier" />
+      <stat name="blessing of foresight:hp" value="level:cleric" />
+    </rules>
+  </element> 
+
+  <element name="Channel Divinity: Prophetic Trance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_CD_PROPHETIC_TRANCE">
+    <description>
+      <p>Starting at 2nd level, you can use your Channel Divinity to enter a prophetic trance. As an action, you inhale hallucinatory vapors and enter a trance-like state for 10 minutes. Roll two d20s and record the numbers rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with one of these prophecy rolls. You must choose to do so before the roll is made. Each prophecy roll can be used only once. You lose the prophecy rolls when your trance ends.</p>
+    </description>
+    <sheet alt="Prophetic Trance" usage="Channel Divinity">
+      <description>As an action, you inhale hallucinatory vapors and enter a trance-like state for 10 minutes. Roll two d20s and record the numbers rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with one of these prophecy rolls. You must choose to do so before the roll is made. Each prophecy roll can be used only once. You lose the prophecy rolls when your trance ends.</description>
+    </sheet>
+  </element> 
+
+  <element name="Visions of Danger" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_VISIONS_OF_DANGER">
+    <description>
+      <p>Starting at 6th level, you experience flashes of foresight that reveal to you when your allies will be harmed, allowing you to react with uncanny speed. When you ready a spell that restores hit points, it does not require or break concentration. Additionally, when one of your allies takes damage or fails a saving throw, you may use your reaction to move up to your speed and cast a beneficial spell that only targets your imperiled ally. The casting time of the spell must be a reaction, action, or bonus action. You may use this feature twice, and you regain any expended uses when you finish a short or long rest.</p>
+    </description>
+    <sheet>
+      <description usage="2/Short Rest" >When you ready a spell that restores hit points, it does not require or break concentration. Additionally, when one of your allies takes damage or fails a saving throw, you may use your reaction to move up to your speed and cast a beneficial spell that only targets your imperiled ally. The casting time of the spell must be a reaction, action, or bonus action.</description>
+    </sheet>
+  </element> 
+
+  <element name="Healing Vapors" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS">
+    <description>
+      <p>Starting at 8th level, your healing spells are accompanied by a mist of restorative vapors. Whenever you use a spell of 1st level or higher to restore hit points to a creature, the creature regains additional hit points equal to your Wisdom modifier.</p>
+      <p class="indent">Additionally, when you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of <i>fog cloud</i> at the location of one of your targets. You must complete a long rest before you can create another fog cloud with this feature.</p>
+    </description>
+    <sheet>
+      <description>Whenever you use a spell of 1st level or higher to restore hit points to a creature, the creature regains additional hit points equal to {{healing vapors:hp}}.</description>
+    </sheet>
+    <rules>
+      <stat name="healing vapors:hp" value="wisdom:modifier" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG" />
+    </rules>
+  </element> 
+
+  <element name="Healing Vapors: Fog Cloud" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG">
+    <sheet>
+      <description usage="1/Long Rest">
+        When you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of fog cloud at the location of one of your targets.
+      </description>
+    </sheet>
+  </element>
+
+  <element name="Perfect Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT">
+    <description>
+      <p>Starting at 17th level, your prophetic powers are nearly infallible. When you enter a prophetic trance with Channel Divinity, you may choose to replace the result of either d20 prophecy roll with any number between 1 and 19 of your choice. Additionally, while you are in the trance, you gain darkvision out to a range of 60 feet, and you can see invisible creatures and objectives within 10 feet of you that are within line of sight.</p>
+    </description>
+    <sheet>
+      <description>When you enter a prophetic trance with Channel Divinity, you may choose to replace the result of either d20 prophecy roll with any number between 1 and 19 of your choice. Additionally, while you are in the trance, you gain darkvision out to a range of 60 feet, and you can see invisible creatures and objectives within 10 feet of you that are within line of sight.</description>
+    </sheet>
+  </element> 
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-cleric-prophecy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml" />
 		</update>
@@ -19,8 +18,8 @@
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT" />
     </description>
-    <sheet>
-      <description>The gods of the forge are patrons of artisans who work with metal, from a humble blacksmith who keeps a village in horseshoes and plow blades to the mighty elf artisan whose diamond-tipped arrows of mithral have felled demon lords.</description>
+    <sheet display="false">
+      <description>The Prophecy domain focuses on foretelling danger and preventing harmful outcomes.</description>
     </sheet>
     <rules>
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_DOMAIN_SPELLS" level="1"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-cleric-prophecy.xml
@@ -121,14 +121,6 @@
       <stat name="healing vapors:hp" value="wisdom:modifier" />
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG" />
     </rules>
-  </element> 
-
-  <element name="Healing Vapors: Fog Cloud" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG">
-    <sheet>
-      <description usage="1/Long Rest">
-        When you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of fog cloud at the location of one of your targets.
-      </description>
-    </sheet>
   </element>
 
   <element name="Perfect Foresight" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_PERFECT_FORESIGHT">
@@ -139,4 +131,13 @@
       <description>When you enter a prophetic trance with Channel Divinity, you may choose to replace the result of either d20 prophecy roll with any number between 1 and 19 of your choice. Additionally, while you are in the trance, you gain darkvision out to a range of 60 feet, and you can see invisible creatures and objectives within 10 feet of you that are within line of sight.</description>
     </sheet>
   </element> 
+
+  <!-- subfeatures -->
+  <element name="Healing Vapors: Fog Cloud" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_PROPHECY_DOMAIN_HEALING_VAPORS_FOG">
+    <sheet>
+      <description usage="1/Long Rest">
+        When you cast a spell of 1st level or higher that restores hit points, you may choose to add the effect of fog cloud at the location of one of your targets.
+      </description>
+    </sheet>
+  </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-druid-sacrifice.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml" />
+		</update>
+	</info>
+  <element name="Circle of Sacrifice" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_DRUID_SACRIFICE">
+    <supports>Druid Circle</supports>
+    <description>
+      <p>Druids of the Circle of Sacrifice believe that nature connects one to the entire universe, including the stars and the astral void between planes. They know that immutable laws have been set down by the great powers of the universe and that sacrifices must be made to these powers in order to keep the balance. Such sacrifices take the form of great bonfires, wherein fallen creatures are immolated.</p>
+      <p class="indent">Druids who keep the Circle of Sacrifice are sometimes called the Keepers of the Old Ways, and they revere mistletoe as a sacred plant connected to the infinite power of the astral plane. Mistletoe must be harvested with extreme care, following rituals that ensure that the plant maintains its potency.</p>
+      <p class="indent">As one of the keepers of the Old Ways, you sometimes gather with others of your kind at sacred rings of standing stones. These standing stones connect the natural world to the heavens and the astral void.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_SACRIFICE" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_MISTLETOE" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_KEEPER_OF_THE_LAW" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM" />
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_SACRIFICE" level="2" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_MISTLETOE" level="6" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_KEEPER_OF_THE_LAW" level="10" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM" level="14" />
+    </rules>
+  </element>
+
+  <element name="Ritual of Sacrifice" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_SACRIFICE">
+    <description>
+      <p>Starting at 2nd level, you learn how to perform a sacrificial ritual that pleases the gods. You know the <i>produce flame</i> cantrip. When you make an attack with <i>produce flame</i>, add your Wisdom modifier to the damage roll.</p>
+    </description>
+    <sheet>
+      <description>When you make an attack with produce flame, add +{{ritual of sacrifice:bonus}} to the damage roll.</description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_PRODUCE_FLAME" />
+      <stat name="ritual of sacrifice:bonus" value="wisdom:modifier" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION" />
+    </rules>
+  </element>
+
+  <element name="Immolation" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION">
+    <description>
+      <p><i><b>Immolation.</b></i> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the <i>bless</i> spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
+    </description>
+    <sheet>
+      <description usage="{{immolation:uses}}/Short Rest">Whenever you reduce a creature to 0 hit points, you may choose to immolate them. If you do, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute (concentration is not required).</description>
+    </sheet>
+    <rules>
+      <stat name="immolation:uses" value="wisdom:modifier" />
+    </rules>
+  </element>
+
+  <element name="Ritual of Mistletoe" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_MISTLETOE">
+    <description>
+      <p>Starting at 6th level, you carry a pouch full of mistletoe that you’ve collected with your sickle. You have sprigs of mistletoe represented by a number of d4s equal to your druid level. On your turn, you may use a bonus action to expend one of the sprigs of mistletoe and perform one of the following effects:</p>
+      <ul>
+        <li><b>Divining Ritual:</b> You cast <i>detect magic</i> without using a spell slot.</li>
+        <li><b>Healing Ritual:</b> You cast <i>cure wounds</i> as a 1st-level spell without using a spell slot.</li>
+        <li><b>Purification Ritual:</b> You cast <i>purify food and drink</i> without using a spell slot.</li>
+        <li><b>Song of the Solstice:</b> You cast <i>heroism</i> as a 1st-level spell without using a spell slot.</li>
+      </ul>
+      <p class="indent">Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs of mistletoe to roll those dice and add them to the number of hit points restored. You regain all expended sprigs of mistletoe after completing a long rest.</p>
+    </description>
+    <sheet>
+      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="6">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d4 per sprig and add them to the number of hit points restored.</description>
+      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="10">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d6 per sprig and add them to the number of hit points restored.</description>
+      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="14">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d8 per sprig and add them to the number of hit points restored.</description>
+    </sheet>
+    <rules>
+      <stat name="mistletoe:sprigs" value="level:druid" />
+    </rules>
+  </element>
+
+  <element name="Keeper of the Law" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_KEEPER_OF_THE_LAW">
+    <description>
+      <p>Starting at 10th level, you are initiated into an ancient order of druidic judges who keep and enforce the laws of the cosmos. Your sprigs of mistletoe increase to d6s.</p>
+      <p class="indent"><b><i>Sacrificial Offering.</i></b> On your turn, you may use a bonus action to choose one creature that you can see. That creature is marked as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll the die and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</p>
+      <p class="indent"><b><i>Restoration Ritual.</i></b> On your turn, you may use an action to expend two sprigs of mistletoe to cast the lesser restoration spell.</p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_OFFERING" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RESTORATION_RITUAL" />
+    </rules>
+  </element>
+
+  <element name="Sacrificial Offering" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_OFFERING">
+    <sheet>
+      <description action="Bonus Action" level="10">Mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d6 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</description>
+      <description action="Bonus Action" level="14">Mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d8 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</description>
+    </sheet>
+  </element>
+
+  <element name="Restoration Ritual" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RESTORATION_RITUAL">
+    <sheet>
+      <description action="Action">Expend two sprigs of mistletoe to cast the lesser restoration spell.</description>
+    </sheet>
+  </element>
+
+  <element name="Astrological Wisdom" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM">
+    <description>
+      <p>Starting at 14th level, you have studied the stars and memorized the pathways that connect the material plane to the astral plane. Your sprigs of mistletoe increase to d8s. Additionally, you gain access to the <i>teleportation circle</i> spell and always have it prepared.</p>
+      <p class="indent"><b><i>Stone Circle.</i></b> You know the ancient methods used to construct a circle of standing stones. You may spend 8 hours and 12,000 gp to construct a circle of twelve standing stones inscribed with druidic sigils, where each stone is 10 feet tall and weighs 1 ton. This stone circle may be used as a permanent anchor location for the <i>teleportation circle</i> spell.</p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" level="14" spellcasting="Druid" prepared="true" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE" />
+    </rules>
+  </element>
+
+  <element name="Stone Circle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE">
+    <sheet>
+      <description>You may spend 8 hours and 12,000 gp to construct a stone circle that may be used as a permanent anchor location for the teleportation circle spell.</description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
@@ -40,18 +40,6 @@
     </rules>
   </element>
 
-  <element name="Immolation" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION">
-    <description>
-      <p><i><b>Immolation.</b></i> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the <i>bless</i> spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
-    </description>
-    <sheet>
-      <description usage="{{immolation:uses}}/Short Rest">Whenever you reduce a creature to 0 hit points, you may choose to immolate them. If you do, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute (concentration is not required).</description>
-    </sheet>
-    <rules>
-      <stat name="immolation:uses" value="wisdom:modifier" />
-    </rules>
-  </element>
-
   <element name="Ritual of Mistletoe" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_MISTLETOE">
     <description>
       <p>Starting at 6th level, you carry a pouch full of mistletoe that you’ve collected with your sickle. You have sprigs of mistletoe represented by a number of d4s equal to your druid level. On your turn, you may use a bonus action to expend one of the sprigs of mistletoe and perform one of the following effects:</p>
@@ -86,6 +74,31 @@
     </rules>
   </element>
 
+  <element name="Astrological Wisdom" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM">
+    <description>
+      <p>Starting at 14th level, you have studied the stars and memorized the pathways that connect the material plane to the astral plane. Your sprigs of mistletoe increase to d8s. Additionally, you gain access to the <i>teleportation circle</i> spell and always have it prepared.</p>
+      <p class="indent"><b><i>Stone Circle.</i></b> You know the ancient methods used to construct a circle of standing stones. You may spend 8 hours and 12,000 gp to construct a circle of twelve standing stones inscribed with druidic sigils, where each stone is 10 feet tall and weighs 1 ton. This stone circle may be used as a permanent anchor location for the <i>teleportation circle</i> spell.</p>
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" level="14" spellcasting="Druid" prepared="true" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE" />
+    </rules>
+  </element>
+
+  <!-- subfeatures -->
+  <element name="Immolation" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION">
+    <description>
+      <p><i><b>Immolation.</b></i> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the <i>bless</i> spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
+    </description>
+    <sheet>
+      <description usage="{{immolation:uses}}/Short Rest">Whenever you reduce a creature to 0 hit points, you may choose to immolate them. If you do, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute (concentration is not required).</description>
+    </sheet>
+    <rules>
+      <stat name="immolation:uses" value="wisdom:modifier" />
+    </rules>
+  </element>
+
   <element name="Sacrificial Offering" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_OFFERING">
     <sheet>
       <description action="Bonus Action" level="10">Mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d6 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</description>
@@ -97,18 +110,6 @@
     <sheet>
       <description action="Action">Expend two sprigs of mistletoe to cast the lesser restoration spell.</description>
     </sheet>
-  </element>
-
-  <element name="Astrological Wisdom" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM">
-    <description>
-      <p>Starting at 14th level, you have studied the stars and memorized the pathways that connect the material plane to the astral plane. Your sprigs of mistletoe increase to d8s. Additionally, you gain access to the <i>teleportation circle</i> spell and always have it prepared.</p>
-      <p class="indent"><b><i>Stone Circle.</i></b> You know the ancient methods used to construct a circle of standing stones. You may spend 8 hours and 12,000 gp to construct a circle of twelve standing stones inscribed with druidic sigils, where each stone is 10 feet tall and weighs 1 ton. This stone circle may be used as a permanent anchor location for the <i>teleportation circle</i> spell.</p>
-    </description>
-    <sheet display="false" />
-    <rules>
-      <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" level="14" spellcasting="Druid" prepared="true" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE" />
-    </rules>
   </element>
 
   <element name="Stone Circle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE">

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
@@ -24,10 +24,10 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM" level="14" />
     </rules>
   </element>
-
   <element name="Ritual of Sacrifice" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_SACRIFICE">
     <description>
       <p>Starting at 2nd level, you learn how to perform a sacrificial ritual that pleases the gods. You know the <i>produce flame</i> cantrip. When you make an attack with <i>produce flame</i>, add your Wisdom modifier to the damage roll.</p>
+      <p class="indent"><strong><em>Immolation.</em></strong> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
     </description>
     <sheet>
       <description>When you make an attack with produce flame, add +{{ritual of sacrifice:bonus}} to the damage roll.</description>
@@ -38,7 +38,18 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION" />
     </rules>
   </element>
-
+  <element name="Immolation" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION">
+    <compendium display="false" />
+    <description>
+      <p><i><b>Immolation.</b></i> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the <i>bless</i> spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
+    </description>
+    <sheet>
+      <description usage="{{wisdom:modifier}}/Short Rest">Whenever you reduce a creature to 0 hit points, you may choose to immolate them. If you do, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute.</description>
+    </sheet>
+    <rules>
+      <stat name="immolation:uses" value="wisdom:modifier" />
+    </rules>
+  </element>
   <element name="Ritual of Mistletoe" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RITUAL_OF_MISTLETOE">
     <description>
       <p>Starting at 6th level, you carry a pouch full of mistletoe that you’ve collected with your sickle. You have sprigs of mistletoe represented by a number of d4s equal to your druid level. On your turn, you may use a bonus action to expend one of the sprigs of mistletoe and perform one of the following effects:</p>
@@ -50,16 +61,15 @@
       </ul>
       <p class="indent">Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs of mistletoe to roll those dice and add them to the number of hit points restored. You regain all expended sprigs of mistletoe after completing a long rest.</p>
     </description>
-    <sheet>
-      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="6">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d4 per sprig and add them to the number of hit points restored.</description>
-      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="10">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d6 per sprig and add them to the number of hit points restored.</description>
-      <description action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest" level="14">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hit points, you may expend any number of sprigs to roll a d8 per sprig and add them to the number of hit points restored.</description>
+    <sheet action="Bonus Action" usage="{{mistletoe:sprigs}} sprigs/Long Rest">
+      <description>You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hp, you may expend any number of sprigs to roll a d4 per sprig and add them to the number of hp restored.</description>
+      <description level="10">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hp, you may expend any number of sprigs to roll a d6 per sprig and add them to the number of hp restored.</description>
+      <description level="14">You can expend a sprig of mistletoe to cast detect magic, cure wounds, purify food and drink or heroism at 1st level without expending a spell slot. Additionally, any time you cast a spell that restores hp, you may expend any number of sprigs to roll a d8 per sprig and add them to the number of hp restored.</description>
     </sheet>
     <rules>
       <stat name="mistletoe:sprigs" value="level:druid" />
     </rules>
   </element>
-
   <element name="Keeper of the Law" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_KEEPER_OF_THE_LAW">
     <description>
       <p>Starting at 10th level, you are initiated into an ancient order of druidic judges who keep and enforce the laws of the cosmos. Your sprigs of mistletoe increase to d6s.</p>
@@ -72,48 +82,29 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RESTORATION_RITUAL" />
     </rules>
   </element>
-
+  <element name="Sacrificial Offering" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_OFFERING">
+    <compendium display="false" />
+    <sheet action="Bonus Action">
+      <description>On your turn, mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d6 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hp, you may activate your Immolation feature on that creature.</description>
+      <description level="14">On your turn, mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d8 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hp, you may activate your Immolation feature on that creature.</description>
+    </sheet>
+  </element>
+  <element name="Restoration Ritual" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RESTORATION_RITUAL">
+    <compendium display="false" />
+    <sheet>
+      <description action="Action">Expend two sprigs of mistletoe to cast the lesser restoration spell.</description>
+    </sheet>
+  </element>
   <element name="Astrological Wisdom" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_ASTROLOGICAL_WISDOM">
     <description>
       <p>Starting at 14th level, you have studied the stars and memorized the pathways that connect the material plane to the astral plane. Your sprigs of mistletoe increase to d8s. Additionally, you gain access to the <i>teleportation circle</i> spell and always have it prepared.</p>
       <p class="indent"><b><i>Stone Circle.</i></b> You know the ancient methods used to construct a circle of standing stones. You may spend 8 hours and 12,000 gp to construct a circle of twelve standing stones inscribed with druidic sigils, where each stone is 10 feet tall and weighs 1 ton. This stone circle may be used as a permanent anchor location for the <i>teleportation circle</i> spell.</p>
     </description>
-    <sheet display="false" />
-    <rules>
-      <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" level="14" spellcasting="Druid" prepared="true" />
-      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE" />
-    </rules>
-  </element>
-
-  <!-- subfeatures -->
-  <element name="Immolation" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_IMMOLATION">
-    <description>
-      <p><i><b>Immolation.</b></i> Whenever you reduce a creature to 0 hit points, you may choose to immolate them as a sacrificial offering. As the creature is engulfed in fire, you and every ally within 60 feet of the immolated creature gain the effects of the <i>bless</i> spell for 1 minute (concentration is not required). You may use this feature a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
-    </description>
-    <sheet>
-      <description usage="{{immolation:uses}}/Short Rest">Whenever you reduce a creature to 0 hit points, you may choose to immolate them. If you do, you and every ally within 60 feet of the immolated creature gain the effects of the bless spell for 1 minute (concentration is not required).</description>
-    </sheet>
-    <rules>
-      <stat name="immolation:uses" value="wisdom:modifier" />
-    </rules>
-  </element>
-
-  <element name="Sacrificial Offering" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_OFFERING">
-    <sheet>
-      <description action="Bonus Action" level="10">Mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d6 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</description>
-      <description action="Bonus Action" level="14">Mark one creature you can see as a Sacrificial Offering for the next hour. Whenever any of your allies hit that creature with an attack, you may use a reaction to expend one of your sprigs of mistletoe to roll a d8 and add the result as fire damage. Additionally, whenever a Sacrificial Offering is reduced to 0 hit points, you may activate your Immolation feature on that creature.</description>
-    </sheet>
-  </element>
-
-  <element name="Restoration Ritual" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_RESTORATION_RITUAL">
-    <sheet>
-      <description action="Action">Expend two sprigs of mistletoe to cast the lesser restoration spell.</description>
-    </sheet>
-  </element>
-
-  <element name="Stone Circle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SACRIFICE_STONE_CIRCLE">
     <sheet>
       <description>You may spend 8 hours and 12,000 gp to construct a stone circle that may be used as a permanent anchor location for the teleportation circle spell.</description>
     </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_TELEPORTATION_CIRCLE" spellcasting="Druid" prepared="true" />
+    </rules>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-druid-sacrifice.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-druid-sacrifice.xml" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-fighter-hoplite.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml" />
+		</update>
+	</info>
+	<element name="Hoplite" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FIGHTER_HOPLITE">
+		<supports>Martial Archetype</supports>
+		<description>
+			<p>The rank-and-file warriors of large cities are sometimes trained to fight in large armies of identically-outfitted soldiers called hoplites. Hoplites fight behind heavy shields, which have notches to accommodate the use of spears and javelins. Additionally, they may carry a sword called a xiphos for close quarters combat. Hoplites are famous for the use of the phalanx formation, which allows many soldiers to band together closely, benefiting from the protection of their neighbor’s shield.</p>
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SPEAR_MASTERY" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_DISCIPLINED_DEFENSE" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_BUSTER" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX_WRECKER" />
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX" level="3" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SPEAR_MASTERY" level="7" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_DISCIPLINED_DEFENSE" level="10" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_BUSTER" level="15" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX_WRECKER" level="18" />
+		</rules>
+	</element>
+
+	<element name="Phalanx (Shield Wall)" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX">
+		<description>
+            <p>Starting when you choose this archetype at 3rd level, you can use a bonus action to activate your Shield Wall ability. You may use this ability once, and you regain the ability to do so after completing a long rest.</p>
+            <p class="indent"><b><i>Shield Wall.</i></b> For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</p>
+        </description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL" />
+		</rules>
+	</element>
+
+    <element name="Shield Wall" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL">
+		<description />
+		<sheet>
+            <description action="Bonus Action" usage="1/Long Rest">For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</description>
+        </sheet>
+	</element>
+
+	<element name="Spear Mastery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SPEAR_MASTERY">
+		<description>
+			<p>Starting at 7th level, your damage dice with spears, tridents, and javelins increases to d8 (d10 when wielded with two hands), and your melee attack range with these weapons is increased to 10 feet. When you make an attack with one of these weapons, you may use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.</p>
+		</description>
+		<sheet>
+			<description>Your damage dice with spears, tridents, and javelins increases to d8 (d10 when wielded with two hands), and your melee attack range with these weapons is increased to 10 feet. When you make an attack with one of these weapons, you may use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.</description>
+		</sheet>
+	</element>
+
+	<element name="Disciplined Defense" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_DISCIPLINED_DEFENSE">
+		<description>
+			<p>Starting at 10th level, you are practiced at using your shield to intercede and protect allies. When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to add your proficiency bonus to the target's AC until the beginning of your next turn. You must be wielding a shield.</p>
+		</description>
+		<sheet>
+			<description action="Reaction">When a creature you can see attacks a target other than you that is within 5 feet of you, add +{{proficiency}} to the target's AC until the beginning of your next turn. You must be wielding a shield.</description>
+		</sheet>
+	</element>
+
+	<element name="Shield Buster" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_BUSTER">
+		<description>
+			<p>Starting at 15th level, your attacks score a critical hit on a roll of 19 or 20. When you score a critical hit with a melee weapon, you knock away your target’s shield if they are wielding one. The shield lands in a free space up to 10 ft. away. If your target is not wielding a shield, then they suffer an additional d6 damage from the sheer force of your weapon attack.</p>
+		</description>
+		<sheet>
+			<description>You crit on a roll of 19 or 20. When you score a critical hit with a melee weapon, you knock your target’s shield 10 feet away if they are wielding one. If your target is not wielding a shield, then they suffer an additional d6 damage from the sheer force of your weapon attack.</description>
+		</sheet>
+	</element>
+
+	<element name="Phalanx Wrecker" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX_WRECKER">
+		<description>
+			<p>Starting at 18th level, you have become a whirling machine of death in close quarters combat. When you take the Attack action, you can forgo one of your attacks to make a single melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</p>
+		</description>
+		<sheet>
+			<description>When you take the Attack action, you can forgo one of your attacks to make a single melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</description>
+		</sheet>
+	</element>
+
+    <!-- Fighting Style -->
+	<element name="Hoplite" type="Class Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_CLASS_FEATURE_FIGHTINGSTYLE_HOPLITE">
+		<supports>Fighting Style, Fighter</supports>
+		<description>
+			<p>While you are wielding a shield, you are alert to attacks made against nearby allies. Whenever a creature attacks an ally standing within 5 feet of you with a melee attack, you may use your reaction to make a melee opportunity attack against the offending creature.</p>
+		</description>
+		<sheet>
+			<description usage="Reaction">While you are wielding a shield, whenever a creature attacks an ally standing within 5 feet of you with a melee attack, make a melee opportunity attack against the offending creature.</description>
+		</sheet>
+	</element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
@@ -37,13 +37,6 @@
 		</rules>
 	</element>
 
-    <element name="Shield Wall" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL">
-		<description />
-		<sheet>
-            <description action="Bonus Action" usage="1/Long Rest">For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</description>
-        </sheet>
-	</element>
-
 	<element name="Spear Mastery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SPEAR_MASTERY">
 		<description>
 			<p>Starting at 7th level, your damage dice with spears, tridents, and javelins increases to d8 (d10 when wielded with two hands), and your melee attack range with these weapons is increased to 10 feet. When you make an attack with one of these weapons, you may use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.</p>
@@ -80,7 +73,15 @@
 		</sheet>
 	</element>
 
-    <!-- Fighting Style -->
+	<!-- subfeatures -->
+	<element name="Shield Wall" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL">
+		<description />
+		<sheet>
+            <description action="Bonus Action" usage="1/Long Rest">For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</description>
+        </sheet>
+	</element>
+
+    <!-- fighting style -->
 	<element name="Hoplite" type="Class Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_CLASS_FEATURE_FIGHTINGSTYLE_HOPLITE">
 		<supports>Fighting Style, Fighter</supports>
 		<description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-fighter-hoplite.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-fighter-hoplite.xml
@@ -23,19 +23,16 @@
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_BUSTER" level="15" />
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX_WRECKER" level="18" />
 		</rules>
-	</element>
-
+	</element>	
 	<element name="Phalanx (Shield Wall)" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX">
 		<description>
             <p>Starting when you choose this archetype at 3rd level, you can use a bonus action to activate your Shield Wall ability. You may use this ability once, and you regain the ability to do so after completing a long rest.</p>
             <p class="indent"><b><i>Shield Wall.</i></b> For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</p>
         </description>
-		<sheet display="false" />
-		<rules>
-			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL" />
-		</rules>
+		<sheet>
+            <description action="Bonus Action" usage="1/Long Rest">You activate your Shield Wall and for 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</description>
+        </sheet>
 	</element>
-
 	<element name="Spear Mastery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SPEAR_MASTERY">
 		<description>
 			<p>Starting at 7th level, your damage dice with spears, tridents, and javelins increases to d8 (d10 when wielded with two hands), and your melee attack range with these weapons is increased to 10 feet. When you make an attack with one of these weapons, you may use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.</p>
@@ -44,7 +41,6 @@
 			<description>Your damage dice with spears, tridents, and javelins increases to d8 (d10 when wielded with two hands), and your melee attack range with these weapons is increased to 10 feet. When you make an attack with one of these weapons, you may use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.</description>
 		</sheet>
 	</element>
-
 	<element name="Disciplined Defense" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_DISCIPLINED_DEFENSE">
 		<description>
 			<p>Starting at 10th level, you are practiced at using your shield to intercede and protect allies. When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to add your proficiency bonus to the target's AC until the beginning of your next turn. You must be wielding a shield.</p>
@@ -53,7 +49,6 @@
 			<description action="Reaction">When a creature you can see attacks a target other than you that is within 5 feet of you, add +{{proficiency}} to the target's AC until the beginning of your next turn. You must be wielding a shield.</description>
 		</sheet>
 	</element>
-
 	<element name="Shield Buster" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_BUSTER">
 		<description>
 			<p>Starting at 15th level, your attacks score a critical hit on a roll of 19 or 20. When you score a critical hit with a melee weapon, you knock away your target’s shield if they are wielding one. The shield lands in a free space up to 10 ft. away. If your target is not wielding a shield, then they suffer an additional d6 damage from the sheer force of your weapon attack.</p>
@@ -62,7 +57,6 @@
 			<description>You crit on a roll of 19 or 20. When you score a critical hit with a melee weapon, you knock your target’s shield 10 feet away if they are wielding one. If your target is not wielding a shield, then they suffer an additional d6 damage from the sheer force of your weapon attack.</description>
 		</sheet>
 	</element>
-
 	<element name="Phalanx Wrecker" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_PHALANX_WRECKER">
 		<description>
 			<p>Starting at 18th level, you have become a whirling machine of death in close quarters combat. When you take the Attack action, you can forgo one of your attacks to make a single melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</p>
@@ -71,15 +65,7 @@
 			<description>When you take the Attack action, you can forgo one of your attacks to make a single melee attack against any number of creatures within 5 feet of you, with a separate attack roll for each target.</description>
 		</sheet>
 	</element>
-
-	<!-- subfeatures -->
-	<element name="Shield Wall" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_HOPLITE_SHIELD_WALL">
-		<description />
-		<sheet>
-            <description action="Bonus Action" usage="1/Long Rest">For 1 minute, you and every ally who can see or hear you gains +2 AC as long as they are standing within 5 feet of an ally who is using a shield. Additionally, your allies wielding shields gain an additional +1 AC from their own shields (this includes you). This ability does not stack with itself.</description>
-        </sheet>
-	</element>
-
+	
     <!-- fighting style -->
 	<element name="Hoplite" type="Class Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_CLASS_FEATURE_FIGHTINGSTYLE_HOPLITE">
 		<supports>Fighting Style, Fighter</supports>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
@@ -22,8 +22,7 @@
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE" level="11"/>
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT" level="17"/>
         </rules>
-    </element>
-    
+    </element>    
     <element name="Aresian Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_ARESIAN_TECHNIQUE">
         <description>
             <p>Starting when you choose this tradition at 3rd level, you gain proficiency with shields. Additionally, wielding a shield does not impede your Martial Arts, Unarmored Movement, or Unarmored Defense features. You may also use your shield as a “free hand” to catch and hold missile weapons with your Deflect Missiles feature.</p>
@@ -34,9 +33,15 @@
         </sheet>
         <rules>
             <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" />
-        </rules>
-    </element>
 
+            <stat name="ac:calculation" value="ac:unarmored defense monk" bonus="calculation" equipped="[armor:none]" alt="Unarmored Defense (Monk)" />
+			<stat name="innate speed:misc" value="monk:unarmored movement" bonus="unarmored movement" equipped="[armor:none]" requirements="[innate speed:1]" />
+			<stat name="innate speed:climb:misc" value="monk:unarmored movement" bonus="unarmored movement" equipped="[armor:none]" requirements="[innate speed:climb:1]" />
+			<stat name="innate speed:fly:misc" value="monk:unarmored movement" bonus="unarmored movement" equipped="[armor:none]" requirements="[innate speed:fly:1]" />
+			<stat name="innate speed:swim:misc" value="monk:unarmored movement" bonus="unarmored movement" equipped="[armor:none]" requirements="[innate speed:swim:1]" />
+			<stat name="innate speed:burrow:misc" value="monk:unarmored movement" bonus="unarmored movement" equipped="[armor:none]" requirements="[innate speed:burrow:1]" />
+        </rules>
+    </element>    
     <element name="Shield Dancer" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHIELD_DANCER">
         <description>
             <p>Starting at 6th level, you have learned new techniques for using shields on the battlefield.</p>
@@ -49,37 +54,32 @@
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK" />
         </rules>
     </element>
-
+    <element name="Vaulting Strike" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE">
+		<compendium display="false" />
+        <sheet>
+            <description action="Bonus Action" usage="Ki">You may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, you have advantage on your first melee attack, and it crits on a 19 or 20.</description>
+        </sheet>
+    </element>
+    <element name="Counterattack" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK">
+		<compendium display="false" />
+        <sheet>
+            <description action="Reaction">Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, make a single melee weapon attack against that creature, without interrupting your movement.</description>
+        </sheet>
+    </element>
     <element name="Shell of the Dragon Turtle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE">
         <description>
             <p>Starting at 11th level, you have learned to think of your shield as an extension of your body. As a reaction when you are attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</p>
         </description>
-        <sheet>
-            <description action="Reaction">When attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</description>
+        <sheet action="Reaction" usage="Ki">
+            <description>When attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</description>
         </sheet>
     </element>
-
     <element name="Undaunted Spirit" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT">
         <description>
             <p>Beginning at 17th level, you are fearless when faced with overwhelming enemies. You have advantage on all attacks made against creatures that are Huge in size or larger. Additionally, you cannot be frightened or paralyzed by spells or abilities used by such creatures.</p>
         </description>
         <sheet>
             <description>You have advantage on all attacks made against creatures that are Huge in size or larger. Additionally, you cannot be frightened or paralyzed by spells or abilities used by such creatures.</description>
-        </sheet>
-    </element>
-
-    <!-- subfeatures -->
-    <element name="Vaulting Strike" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE">
-        <description/>
-        <sheet>
-            <description action="Bonus Action">You may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, you have advantage on your first melee attack, and it crits on a 19 or 20.</description>
-        </sheet>
-    </element>
-
-    <element name="Counterattack" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK">
-        <description/>
-        <sheet>
-            <description action="Reaction">Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, make a single melee weapon attack against that creature, without interrupting your movement.</description>
         </sheet>
     </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-monk-shield.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml" />
 		</update>
@@ -16,7 +15,7 @@
             <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE" />
             <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT" />
         </description>
-        <sheet />
+        <sheet display="false" />
         <rules>
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_ARESIAN_TECHNIQUE" level="3"/>
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHIELD_DANCER" level="6"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
@@ -51,20 +51,6 @@
         </rules>
     </element>
 
-    <element name="Vaulting Strike" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE">
-        <description/>
-        <sheet>
-            <description action="Bonus Action">You may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, you have advantage on your first melee attack, and it crits on a 19 or 20.</description>
-        </sheet>
-    </element>
-
-    <element name="Counterattack" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK">
-        <description/>
-        <sheet>
-            <description action="Reaction">Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, make a single melee weapon attack against that creature, without interrupting your movement.</description>
-        </sheet>
-    </element>
-
     <element name="Shell of the Dragon Turtle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE">
         <description>
             <p>Starting at 11th level, you have learned to think of your shield as an extension of your body. As a reaction when you are attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</p>
@@ -80,6 +66,21 @@
         </description>
         <sheet>
             <description>You have advantage on all attacks made against creatures that are Huge in size or larger. Additionally, you cannot be frightened or paralyzed by spells or abilities used by such creatures.</description>
+        </sheet>
+    </element>
+
+    <!-- subfeatures -->
+    <element name="Vaulting Strike" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE">
+        <description/>
+        <sheet>
+            <description action="Bonus Action">You may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, you have advantage on your first melee attack, and it crits on a 19 or 20.</description>
+        </sheet>
+    </element>
+
+    <element name="Counterattack" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK">
+        <description/>
+        <sheet>
+            <description action="Reaction">Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, make a single melee weapon attack against that creature, without interrupting your movement.</description>
         </sheet>
     </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-monk-shield.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-monk-shield.xml" />
+		</update>
+	</info>
+    <element name="Way of the Shield" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_WAY_OF_THE_SHIELD">
+        <supports>Monastic Tradition</supports>
+        <description>
+            <p>Some monasteries teach a specialized form of combat that is very different from traditional monk fighting techniques. This style is known as the Way of the Shield, and it emphasizes the shield as a living extension of the warrior. Monks of this tradition train to take advantage of shields and polearms, so that they can fight with or against large armies of hoplites in phalanx formations. Such monks commonly wear long red cloaks to disguise their intentions and add fluidity to their movements.</p>
+            <p class="indent">Temples that teach the Way of the Shield are often decorated with scrolls that exalt the feats of warriors who are fearless when faced with impossible odds. Massive armies may be surprised to encounter resistance from a proud band of shield monks with less than a tenth of their numbers. Grandmasters of this tradition have even been known to stand alone against creatures many times their size.</p>
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_ARESIAN_TECHNIQUE" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHIELD_DANCER" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT" />
+        </description>
+        <sheet />
+        <rules>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_ARESIAN_TECHNIQUE" level="3"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHIELD_DANCER" level="6"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE" level="11"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT" level="17"/>
+        </rules>
+    </element>
+    
+    <element name="Aresian Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_ARESIAN_TECHNIQUE">
+        <description>
+            <p>Starting when you choose this tradition at 3rd level, you gain proficiency with shields. Additionally, wielding a shield does not impede your Martial Arts, Unarmored Movement, or Unarmored Defense features. You may also use your shield as a “free hand” to catch and hold missile weapons with your Deflect Missiles feature.</p>
+            <p class="indent">As long as you are wielding a shield, opportunity attacks against you are made with disadvantage.</p>
+        </description>
+        <sheet>
+            <description>Wielding a shield does not impede your Martial Arts, Unarmored Movement, or Unarmored Defense features. You may also use your shield as a “free hand” to catch and hold missile weapons with your Deflect Missiles feature. While you are wielding a shield, opportunity attacks against you are made with disadvantage.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" />
+        </rules>
+    </element>
+
+    <element name="Shield Dancer" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHIELD_DANCER">
+        <description>
+            <p>Starting at 6th level, you have learned new techniques for using shields on the battlefield.</p>
+            <p class="indent"><b><i>Vaulting Strike.</i></b> As a bonus action on your turn, you may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, then you have advantage on your first melee attack, and it scores a critical hit on a roll of 19 or 20.</p>
+            <p class="indent"><b><i>Counterattack.</i></b> Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, you may use your reaction to spin around and make a single melee weapon attack against that creature, without interrupting your movement.</p>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK" />
+        </rules>
+    </element>
+
+    <element name="Vaulting Strike" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_VAULTING_STRIKE">
+        <description/>
+        <sheet>
+            <description action="Bonus Action">You may spend 1 ki point to vault yourself into the air, leaping up to 15 feet in any direction. If you are wielding a shield, then this leap does not provoke opportunity attacks. If you take an Attack action immediately after leaping, you have advantage on your first melee attack, and it crits on a 19 or 20.</description>
+        </sheet>
+    </element>
+
+    <element name="Counterattack" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_COUNTERATTACK">
+        <description/>
+        <sheet>
+            <description action="Reaction">Whenever a creature makes an opportunity attack against you and misses, if you are using a shield, make a single melee weapon attack against that creature, without interrupting your movement.</description>
+        </sheet>
+    </element>
+
+    <element name="Shell of the Dragon Turtle" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_SHELL_DRAGON_TURTLE">
+        <description>
+            <p>Starting at 11th level, you have learned to think of your shield as an extension of your body. As a reaction when you are attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</p>
+        </description>
+        <sheet>
+            <description action="Reaction">When attacked, you may spend 1 ki point to gain an additional +3 AC from your shield, including against the triggering attack, until the beginning of your next turn.</description>
+        </sheet>
+    </element>
+
+    <element name="Undaunted Spirit" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_SHIELD_UNDAUNTED_SPIRIT">
+        <description>
+            <p>Beginning at 17th level, you are fearless when faced with overwhelming enemies. You have advantage on all attacks made against creatures that are Huge in size or larger. Additionally, you cannot be frightened or paralyzed by spells or abilities used by such creatures.</p>
+        </description>
+        <sheet>
+            <description>You have advantage on all attacks made against creatures that are Huge in size or larger. Additionally, you cannot be frightened or paralyzed by spells or abilities used by such creatures.</description>
+        </sheet>
+    </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
@@ -88,20 +88,6 @@
 	</rules>
   </element>
 
-  <element name="Channel Divinity: Dragon's Wrath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_DRAGONS_WRATH">
-    <description />>
-    <sheet alt="Dragon's Wrath" action="Action" usage="Channel Divinity">
-      <description>Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</description>
-    </sheet>
-  </element>
-
-  <element name="Channel Divinity: Scorn the Unworthy" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_SCORN_UNWORTHY">
-    <description />
-    <sheet alt="Scorn the Unworthy" action="Action" usage="Channel Divinity">
-      <description>Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</description>
-    </sheet>
-  </element>
-
   <element name="Dragonlord's Bond" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_DRAGONLORDS_BOND">
     <description>
       <p>At 7th level, your dragon egg will hatch. You must cast the spell <i>bond of the dragonlords</i> while touching the newborn wyrmling within 24 hours of it hatching. The dragon wyrmling is now bonded to you. Additionally, you may cast the spells <i>bond of the dragonlords</i> and <i>dirge of the dragonlords</i>, and they require no material components when you cast them. Your wyrmling has hit points equal to 40 + twice your paladin level, and it adds your proficiency bonus to its saving throws.</p>
@@ -136,6 +122,21 @@
     <rules>
         <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB" />
     </rules>
+  </element>
+
+  <!-- subfeatures -->
+  <element name="Channel Divinity: Dragon's Wrath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_DRAGONS_WRATH">
+    <description />>
+    <sheet alt="Dragon's Wrath" action="Action" usage="Channel Divinity">
+      <description>Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</description>
+    </sheet>
+  </element>
+
+  <element name="Channel Divinity: Scorn the Unworthy" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_SCORN_UNWORTHY">
+    <description />
+    <sheet alt="Scorn the Unworthy" action="Action" usage="Channel Divinity">
+      <description>Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</description>
+    </sheet>
   </element>
 
   <element name="Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB">

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-paladin-dragonlord.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml" />
 		</update>
@@ -19,8 +18,8 @@
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_YOUNG_DRAGON" />
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND" />
     </description>
-    <sheet>
-      <description>The Oath of Conquest sets a paladin on a difficult path, one that requires a holy warrior to use violence only as a last resort.</description>
+    <sheet display="false">
+      <description>Dragonlords are paladins who seek to extend their reach across the land by binding a dragon into their service.</description>
     </sheet>
     <rules>
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_OATH_SPELLS" level="3" />

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-paladin-dragonlord.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml" />
+		</update>
+	</info>
+  <element name="Oath of the Dragonlord" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_OATH_OF_THE_DRAGONLORD">
+    <supports>Sacred Oath</supports>
+    <description>
+      <p>Dragonlords are paladins who seek to extend their reach across the land by binding a dragon into their service. Such a task should never be undertaken lightly. Forming a true bond with a dragon requires a paladin to hatch a dragon egg and raise the wyrmling from the first moment it draws breath. Raising a dragon in this way requires the paladin to lay their life on the line by swearing an oath. This oath creates a reciprocal bond between the paladin’s soul and the soul of the dragon.</p>
+      <p class="indent">But finding a dragon egg is no easy task either. For this reason, Dragonlords summon pseudodragon familiars and train them to seek out the perfect egg. This process may take years, and many paladins come to view the pseudodragon as a partner in the oath. When an egg is finally discovered, the paladin and the pseudodragon may share an almost parental pride in the hatchling.</p>
+      <p class="indent">Once the paladin’s dragon is grown, its master becomes a true Dragonlord. But the paladin is as much a servant to the dragon as the dragon is to its master. The two are one—their destinies are interlinked—and whatsoever pain is suffered by one is also felt by the other.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_OATH_SPELLS" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_PSEUDODRAGON_FAMILIAR" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_DRAGONLORDS_BOND" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_YOUNG_DRAGON" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND" />
+    </description>
+    <sheet>
+      <description>The Oath of Conquest sets a paladin on a difficult path, one that requires a holy warrior to use violence only as a last resort.</description>
+    </sheet>
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_OATH_SPELLS" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_PSEUDODRAGON_FAMILIAR" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY" level="3" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_DRAGONLORDS_BOND" level="7" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_YOUNG_DRAGON" level="15" />
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND" level="20" />
+    </rules>
+  </element>
+
+  <element name="Oath Spells" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_OATH_SPELLS">
+    <description>
+      <p>Starting when you swear your oath at 3rd level, you gain Oath Spells at the listed levels and always have them prepared</p>
+      <h5>Oath of the Dragonlord Spells</h5>
+      <table>
+        <thead>
+        <tr><td>Paladin Level</td><td>Spells</td></tr>
+        </thead>
+        <tr><td>3rd</td><td><em>hunter's mark, find familiar</em></td></tr>
+        <tr><td>5th</td><td><em>gust of wind, levitate</em></td></tr>
+        <tr><td>9th</td><td><em>fly, haste</em></td></tr>
+        <tr><td>13th</td><td><em>freedom of movement, stoneskin</em></td></tr>
+        <tr><td>17th</td><td><em>hold monster, telepathic bond</em></td></tr>
+      </table>      
+    </description>
+    <sheet display="false">
+      <description>You gain oath spells at the paladin levels listed in the Oath of Conquest Spells table.</description>
+    </sheet>
+    <rules>
+      <grant type="Spell" id="ID_PHB_SPELL_HUNTERS_MARK" level="3" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_FIND_FAMILIAR" level="3" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_GUST_OF_WIND" level="5" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_LEVITATE" level="5" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_FLY" level="9" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_HASTE" level="9" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_FREEDOM_OF_MOVEMENT" level="13" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_STONESKIN" level="13" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_HOLD_MONSTER" level="17" spellcasting="Paladin" prepared="true" />
+      <grant type="Spell" id="ID_PHB_SPELL_RARYS_TELEPATHIC_BOND" level="17" spellcasting="Paladin" prepared="true" />
+    </rules>
+  </element>
+
+  <element name="Pseudodragon Familiar" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_PSEUDODRAGON_FAMILIAR">
+    <description>
+      <p>When you cast the <i>find familiar</i> spell, you summon a <b>pseudodragon</b> instead of one of the normal forms described in the spell. The pseudodragon's primary purpose is to find you a dragon egg. The pseudodragon can smell dragon eggs if they are within one mile.</p>
+      <p class="indent">The pseudodragon is likely to find a dragon egg by the time you are 5th level, but it might be earlier. If your pseudodragon hasn’t found a dragon egg by 6th level, then it departs in search of one. In 3d6 days, the pseudodragon returns to you with a dragon egg of your choice from this list: brass, bronze, copper, or silver.</p>
+      <p class="indent">If at any time your dragon egg is lost or destroyed, your pseudodragon will depart in search of another one. It will return in 3d6 days with the lost egg or a suitable replacement. If you deliberately lose or destroy your egg, then your pseudodragon refuses to perform this service.</p>
+    </description>
+    <sheet>
+        <description>When you cast the find familiar spell, you summon a pseudodragon. The pseudodragon can smell dragon eggs if they are within one mile. If your pseudodragon hasn’t found a dragon egg by 6th level, then it departs in search of one. In 3d6 days, the pseudodragon returns to you with a dragon egg of your choice from this list: brass, bronze, copper, or silver. If at any time your dragon egg is lost or destroyed, your pseudodragon will depart in search of another one. It will return in 3d6 days with the lost egg or a suitable replacement. If you deliberately lose or destroy your egg, then your pseudodragon refuses to perform this service.</description>
+    </sheet>
+  </element>
+
+  <element name="Channel Divinity" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY">
+    <description>
+      <p>When you take this oath at 3rd level, you gain the following two Channel Divinity options.</p>
+      <p class="indent"><b><i>Dragon's Wrath.</i></b> As an action, you can mimic the frightful presence of a dragon, using your Channel Divinity. You issue a roar as loud as an adult dragon. Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
+      <p class="indent"><b><i>Scorn the Unworthy. </i></b> Your dragonlord oath elevates you above the multitudes of the corrupt and the weak. As an action, you can intone the Dragonlord’s oath, using your Channel Divinity. Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</p>
+    </description>
+    <sheet display="false" />
+	<rules>
+		<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_DRAGONS_WRATH" />
+		<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_SCORN_UNWORTHY" />
+	</rules>
+  </element>
+
+  <element name="Channel Divinity: Dragon's Wrath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_DRAGONS_WRATH">
+    <description />>
+    <sheet alt="Dragon's Wrath" action="Action" usage="Channel Divinity">
+      <description>Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</description>
+    </sheet>
+  </element>
+
+  <element name="Channel Divinity: Scorn the Unworthy" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_SCORN_UNWORTHY">
+    <description />
+    <sheet alt="Scorn the Unworthy" action="Action" usage="Channel Divinity">
+      <description>Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</description>
+    </sheet>
+  </element>
+
+  <element name="Dragonlord's Bond" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_DRAGONLORDS_BOND">
+    <description>
+      <p>At 7th level, your dragon egg will hatch. You must cast the spell <i>bond of the dragonlords</i> while touching the newborn wyrmling within 24 hours of it hatching. The dragon wyrmling is now bonded to you. Additionally, you may cast the spells <i>bond of the dragonlords</i> and <i>dirge of the dragonlords</i>, and they require no material components when you cast them. Your wyrmling has hit points equal to 40 + twice your paladin level, and it adds your proficiency bonus to its saving throws.</p>
+    </description>
+    <sheet>
+      <description>The spells bond of the dragonlords and dirge of the dragonlords require no material components when you cast them. Your wyrmling has hit points equal to {{dragonlord bond:hp}}, and it adds your proficiency bonus to its saving throws.</description>
+    </sheet>
+    <rules>
+      <stat name="dragonlord bond:hp" value="40" />
+      <stat name="dragonlord bond:hp" value="level:paladin" />
+      <stat name="dragonlord bond:hp" value="level:paladin" />
+    </rules>
+  </element>
+
+  <element name="Young Dragon" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_YOUNG_DRAGON">
+    <description>
+      <p>By 15th level, your dragon grows into a young dragon of the appropriate type if five years have not yet passed since its hatching. The dragon will now allow itself to be used as a mount. In addition, while mounted on a dragon, you gain that dragon’s damage resistances, damage immunities, and senses (blindsight, darkvision, and its passive Perception if it is greater than yours).</p>
+    </description>
+    <sheet>
+      <description>Your dragon is a young dragon now and can be used as a mount. While mounted on a dragon, you gain that dragon’s damage resistances, damage immunities, and senses.</description>
+    </sheet>
+  </element>
+
+  <element name="Unbreakable Bond" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND">
+    <description>
+      <p>By 20th level, you and your dragon have learned to fight in unison on the battlefield. Your dragon gains access to its Multiattack feature, and its breath weapon now recharges using the normal rules each round instead of using the restriction outlined in <i>bond of the dragonlords</i>.</p>
+      <p class="indent">Additionally, when your dragon fails a saving throw, you may choose to have it succeed instead. This ability recharges after you and the dragon complete a long rest.</p>
+    </description>
+    <sheet>
+      <description>Your dragon has access to its Multiattack feature, and its breath weapon now recharges using the normal rules each round instead of using the restriction outlined in bond of the dragonlords.</description>
+    </sheet>
+    <rules>
+        <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB" />
+    </rules>
+  </element>
+
+  <element name="Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB">
+    <supports>Unbreakable Bond</supports>
+    <description />
+    <sheet>
+      <description usage="1/Long Rest">When your dragon fails a saving throw, you may choose to have it succeed instead.</description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-paladin-dragonlord.xml
@@ -30,11 +30,10 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND" level="20" />
     </rules>
   </element>
-
   <element name="Oath Spells" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_OATH_SPELLS">
     <description>
       <p>Starting when you swear your oath at 3rd level, you gain Oath Spells at the listed levels and always have them prepared</p>
-      <h5>Oath of the Dragonlord Spells</h5>
+      <h5 class="caption">OATH OF THE DRAGONLORD SPELLS</h5>
       <table>
         <thead>
         <tr><td>Paladin Level</td><td>Spells</td></tr>
@@ -62,7 +61,6 @@
       <grant type="Spell" id="ID_PHB_SPELL_RARYS_TELEPATHIC_BOND" level="17" spellcasting="Paladin" prepared="true" />
     </rules>
   </element>
-
   <element name="Pseudodragon Familiar" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_PSEUDODRAGON_FAMILIAR">
     <description>
       <p>When you cast the <i>find familiar</i> spell, you summon a <b>pseudodragon</b> instead of one of the normal forms described in the spell. The pseudodragon's primary purpose is to find you a dragon egg. The pseudodragon can smell dragon eggs if they are within one mile.</p>
@@ -73,7 +71,6 @@
         <description>When you cast the find familiar spell, you summon a pseudodragon. The pseudodragon can smell dragon eggs if they are within one mile. If your pseudodragon hasn’t found a dragon egg by 6th level, then it departs in search of one. In 3d6 days, the pseudodragon returns to you with a dragon egg of your choice from this list: brass, bronze, copper, or silver. If at any time your dragon egg is lost or destroyed, your pseudodragon will depart in search of another one. It will return in 3d6 days with the lost egg or a suitable replacement. If you deliberately lose or destroy your egg, then your pseudodragon refuses to perform this service.</description>
     </sheet>
   </element>
-
   <element name="Channel Divinity" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY">
     <description>
       <p>When you take this oath at 3rd level, you gain the following two Channel Divinity options.</p>
@@ -116,33 +113,26 @@
       <p class="indent">Additionally, when your dragon fails a saving throw, you may choose to have it succeed instead. This ability recharges after you and the dragon complete a long rest.</p>
     </description>
     <sheet>
-      <description>Your dragon has access to its Multiattack feature, and its breath weapon now recharges using the normal rules each round instead of using the restriction outlined in bond of the dragonlords.</description>
+      <description>Your dragon has access to its Multiattack feature, and its breath weapon now recharges using the normal rules each round instead of using the restriction outlined in bond of the dragonlords.
+      Additionally, when your dragon fails a saving throw, you may choose to have it succeed instead. This ability recharges after you and the dragon complete a long rest.</description>
     </sheet>
-    <rules>
-        <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB" />
-    </rules>
   </element>
-
-  <!-- subfeatures -->
+  
   <element name="Channel Divinity: Dragon's Wrath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_DRAGONS_WRATH">
-    <description />>
+    <description>
+      <p>As an action, you can mimic the frightful presence of a dragon, using your Channel Divinity. You issue a roar as loud as an adult dragon. Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
+    </description>
     <sheet alt="Dragon's Wrath" action="Action" usage="Channel Divinity">
       <description>Each creature of your choice that is within 60 ft. of you and aware of you must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</description>
     </sheet>
   </element>
 
   <element name="Channel Divinity: Scorn the Unworthy" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_CHANNEL_DIVINITY_SCORN_UNWORTHY">
-    <description />
+     <description>
+      <p>Your dragonlord oath elevates you above the multitudes of the corrupt and the weak. As an action, you can intone the Dragonlord’s oath, using your Channel Divinity. Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</p>
+    </description>
     <sheet alt="Scorn the Unworthy" action="Action" usage="Channel Divinity">
       <description>Enemy creatures within 30 feet that are Large or smaller in size must make a Charisma saving throw. On a failed save, the creature falls prone and loses concentration on any spells that it has active.</description>
-    </sheet>
-  </element>
-
-  <element name="Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_OATH_OF_THE_DRAGONLORD_UNBREAKABLE_BOND_SUB">
-    <supports>Unbreakable Bond</supports>
-    <description />
-    <sheet>
-      <description usage="1/Long Rest">When your dragon fails a saving throw, you may choose to have it succeed instead.</description>
     </sheet>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
@@ -30,11 +30,10 @@
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS" level="15" />
         </rules>
     </element>
-
     <element name="Amazonian Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC">
         <description>
-            <p>Starting when you swear your oath at 3rd level, you gain Oath Spells at the listed levels and always have them prepared.</p>       
-            <h5>Amazonian Spells</h5>
+            <p>Starting at 3rd level, you learn an additional spell when you reach certain levels in this class, as shown in the Amazonian Spells table. The spell counts as a ranger spell for you, but it doesn’t count against the number of ranger spells you know.</p>       
+            <h5 class="caption">AMAZONIAN SPELLS</h5>
             <table>
                 <thead>
                     <tr><td>Ranger Level</td><td>Spells</td></tr>
@@ -55,7 +54,6 @@
             <grant type="Spell" id="ID_PHB_SPELL_MISLEAD" level="17" spellcasting="Ranger" />
         </rules>
     </element>
-
     <element name="Stimfay Companion" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_STIMFAY_COMPANION">
         <description>
             <p>At 3rd level, you construct a <b>stimfay</b> companion to accompany you on your travels. Stimfay are clockwork birds of prey that assist an Amazon with stalking her quarry. Choose from the following list of creatures for your stimfay’s appearance: eagle, harrier, hawk, kite, osprey, owl, or archaeopteryx. Your stimfay’s appearance does not affect its abilities, but it does influence its personality.</p>
@@ -67,10 +65,9 @@
             <description>In areas that are open to the sky, you can direct your stimfay to spend 10 minutes scouting the surrounding 1 mile radius and report back to you with anything it has seen. The stimfay obeys your commands to the best of its abilities, and it acts on your initiative in combat. If you are incapacitated, your stimfay acts on its own. Your stimfay adds your proficiency bonus to its attacks, damage, and ability save DCs. It regains any lost hit points during a long rest. If it is ever destroyed, you may spend 8 hours to fully repair it.</description>
         </sheet>
         <rules>
-            <select type="Companion" name="Stimfay" supports="Stimfay Companion" default="ID_AW_OOTD_COMPANION_RANGER_AMAZONIAN_STIMFAY" />
+            <select type="Companion" name="Stimfay Companion" supports="Stimfay Companion" default="ID_AW_OOTD_COMPANION_RANGER_AMAZONIAN_STIMFAY" />            
         </rules>
     </element>
-
     <element name="Amazonian Battlecry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY">
         <description>
             <p>At 3rd level, you gain the ability to enter the legendary frenzy of the Amazons by shouting your signature battlecry. On your turn, you can use a bonus action to shout your battlecry and enter a frenzy. Your frenzy lasts for 1 minute and grants you the following benefits. It ends after you take damage—or when you are knocked unconscious.</p>
@@ -82,10 +79,13 @@
             <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain any expended uses when you finish a long rest.</p>
         </description>
         <sheet>
-            <description action="Bonus Action" usage="{{wisdom:modifier}}/Long Rest">You enter a frenzy that lasts for 1 minute or until you take damage or are knocked unconscious. While in this frenzy, you have advantage on attacks against creatures of your favored enemy type, esistance to bludgeoning, piercing, and slashing damage and advantage on saving throws against being frightened or paralyzed.</description>
+            <description action="Bonus Action" usage="{{amazonian battlecry:usage}}/Long Rest">You enter a frenzy that lasts for 1 minute or until you take damage or are knocked unconscious. While in this frenzy, you have advantage on attacks against creatures of your favored enemy type, esistance to bludgeoning, piercing, and slashing damage and advantage on saving throws against being frightened or paralyzed.</description>
         </sheet>
+        <rules>
+            <stat name="amazonian battlecry:usage" value="1" bonus="base" />
+            <stat name="amazonian battlecry:usage" value="wisdom:modifier" bonus="base" />
+        </rules>
     </element>
-
     <element name="Bracer Reflection" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION">
         <description>
             <p>Starting at 5th level, you've learned to reflect attacks with your bracers. Whenever you would be hit by an attack, you may use your reaction to shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn. You may use this feature a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a short or long rest.</p>
@@ -98,7 +98,6 @@
             <stat name="bracer reflection:uses" value="wisdom:modifier" bonus="base" />
         </rules>
     </element>
-
     <element name="Chakram Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE">
         <description>
             <p>Starting at 7th level, you’ve learned the famous Amazonian technique of ricocheting your chakram to hit multiple targets. You can also throw it at targets that are not in your line of sight, such as around corners.</p>
@@ -108,7 +107,6 @@
             <description>When you use your action to make a ranged attack with your chakram against one target and the attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</description>
         </sheet>
     </element>
-
     <element name="Improved Falconry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY">
         <description>
             <p>At 11th level, your stimfay matures. It gains a bonus to its AC equal to your proficiency bonus, and it now has hit points equal to 30 + your ranger level. The damage dice for its Talons, Pinion Storm, and Piercing Screech increase to 2d6, and its attacks are now magical.</p>
@@ -118,7 +116,6 @@
             <description action="Reaction">If you would take damage from an attack or an effect that you can see, your stimfay takes the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</description>
         </sheet>
     </element>
-
     <element name="Pressure Points" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS">
         <description>
             <p>Starting at 15th level, you know how to attack pressure points in your opponent’s body that will cut off the blood supply to their brain. On your turn, you may use a bonus action to make a special melee attack against one creature. If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds. You may use this ability a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
@@ -146,7 +143,6 @@
 			<set name="speed">10 ft., fly 80 ft.</set>
 			<set name="immunities">fire, poison, psychic</set>
 			<set name="conditionImmunities">charmed, poisoned</set>
-			<set name="saves" />
 			<set name="skills">Perception +3</set>
 			<set name="senses">darkvision 60 ft., passive Perception 13</set>
 			<set name="languages">understands the languages you speak</set>
@@ -158,25 +154,19 @@
 			<set name="actions">ID_AW_OOTD_COMPANION_ACTION_STIMFAY_TALONS,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PINION_STORM,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PIERCING_SCREECH</set>
 			<set name="reactions" />
 		</setters>
-        <!--
 		<rules>
 			<stat name="companion:ac" value="13" />
             <stat name="companion:ac" value="proficiency" level="11" />
 			<stat name="companion:hp:max" value="15" />
             <stat name="companion:hp:max" value="15" level="11" />
 			<stat name="companion:hp:max" value="level:ranger" />
-            <stat name="companion:speed" value="10" />
+            <stat name="companion:speed" value="10" bonus="base" />
+            <stat name="companion:speed:fly" value="80" bonus="base" />
             <stat name="companion:attack" value="proficiency" />
 			<stat name="companion:damage" value="proficiency" />
-            <stat name="companion:save" value="proficiency" />
-            <stat name="companion:intsave" value="-2" />
-            <stat name="companion:intsave" value="proficiency" />
-            <stat name="companion:wissave" value="-1" />
-            <stat name="companion:wissave" value="proficiency" />
-            <stat name="companion:chasave" value="-2" />
-            <stat name="companion:chasave" value="proficiency" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="base" />
+			<stat name="companion:perception:proficiency" value="companion:proficiency" bonus="double" />
 		</rules>
-        -->
 	</element>
 
     <element name="Keen Sight" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_KEEN_SIGHT">

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-ranger-amazonian.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml" />
+		</update>
+	</info>
+    <element name="Amazonian" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_RANGER_AMAZONIAN">
+        <supports>Ranger Archetype, Ranger Conclave</supports>
+        <description>
+            <p>The Amazons are a warrior culture that emphasize the strength of the individual, in contrast to societies that defend themselves with large armies of hoplites and mounted cavalry. A typical Amazonian conclave will outline its territory, usually an island, and fight viciously to drive away trespassers. When the territory is threatened, they may band together into war parties, whose collective battlecries are said to strike fear into enemies up to a mile away.</p>
+            <p class="indent">A lone Amazonian huntress relies upon her mechanical companion, an avian <i>stimfay</i>, for support in battle. Every huntress learns to build and repair these mechanical birds when they are young, often forming deep and lasting bonds with the strange creatures. Each huntress is formidable in close quarters with her deadly kopis blade, but she also trains with an exotic ranged weapon called the <i>chakram</i>.</p>
+            <p class="indent">Amazonian conclaves are ruled by women, and huntresses are almost exclusively female. Men are generally regarded as the weaker sex, but they may be trained in the arts on occasion—for example, when a mother who wishes for a daughter is given a son instead.</p>
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_STIMFAY_COMPANION" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS" />
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC" level="3" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_STIMFAY_COMPANION" level="3" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY" level="3" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION" level="5" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE" level="7" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY" level="11" />
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS" level="15" />
+        </rules>
+    </element>
+
+    <element name="Amzaonian Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC">
+        <description>
+            <p>Starting when you swear your oath at 3rd level, you gain Oath Spells at the listed levels and always have them prepared.</p>       
+            <h5>Amazonian Spells</h5>
+            <table>
+                <thead>
+                    <tr><td>Ranger Level</td><td>Spells</td></tr>
+                </thead>
+                <tr><td>3rd</td><td><em>command</em></td></tr>
+                <tr><td>5rd</td><td><em>find steed</em></td></tr>
+                <tr><td>9th</td><td><em>haste</em></td></tr>
+                <tr><td>13th</td><td><em>confusion</em></td></tr>
+                <tr><td>17th</td><td><em>mislead</em></td></tr>
+            </table>
+        </description>
+        <sheet display="false" />
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_COMMAND" level="3" spellcasting="Ranger"/>
+            <grant type="Spell" id="ID_PHB_SPELL_FIND_STEED" level="5" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_HASTE" level="9" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_CONFUSION" level="13" spellcasting="Ranger" />
+            <grant type="Spell" id="ID_PHB_SPELL_MISLEAD" level="17" spellcasting="Ranger" />
+        </rules>
+    </element>
+
+    <element name="Stimfay Companion" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_STIMFAY_COMPANION">
+        <description>
+            <p>At 3rd level, you construct a <b>stimfay</b> companion to accompany you on your travels. Stimfay are clockwork birds of prey that assist an Amazon with stalking her quarry. Choose from the following list of creatures for your stimfay’s appearance: eagle, harrier, hawk, kite, osprey, owl, or archaeopteryx. Your stimfay’s appearance does not affect its abilities, but it does influence its personality.</p>
+            <p class="indent">In areas that are open to the sky, you can direct your stimfay to spend 10 minutes scouting the surrounding 1 mile radius and report back to you with anything it has seen. It comprehends instructions that you give it in any language. It speaks in a series of clicks and squawks that only you can understand.</p>
+            <p class="indent">The stimfay obeys your commands to the best of its abilities, and it acts on your initiative in combat. If you are incapacitated, your stimfay acts on its own.</p>
+            <p class="indent">Your stimfay has hit points equal to 15 + your ranger level, and it adds your proficiency bonus to its attacks, damage, saving throws, and ability save DCs. It regains any lost hit points during a long rest. If it is ever destroyed, you may spend 8 hours to fully repair it.</p>
+        </description>
+        <sheet>
+            <description>In areas that are open to the sky, you can direct your stimfay to spend 10 minutes scouting the surrounding 1 mile radius and report back to you with anything it has seen. The stimfay obeys your commands to the best of its abilities, and it acts on your initiative in combat. If you are incapacitated, your stimfay acts on its own. Your stimfay adds your proficiency bonus to its attacks, damage, and ability save DCs. It regains any lost hit points during a long rest. If it is ever destroyed, you may spend 8 hours to fully repair it.</description>
+        </sheet>
+        <rules>
+            <select type="Companion" name="Stimfay" supports="Stimfay Companion" default="ID_AW_OOTD_COMPANION_RANGER_AMAZONIAN_STIMFAY" />
+        </rules>
+    </element>
+
+    <element name="Stimfay" type="Companion" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_RANGER_AMAZONIAN_STIMFAY">
+		<supports>Stimfay Companion</supports>
+		<description>
+			<p>You constructed a stimfay companion to accompany you on your travels.</p>
+		</description>
+		<setters>
+			<set name="strength">10</set>
+			<set name="dexterity">11</set>
+			<set name="constitution">10</set>
+			<set name="intelligence">6</set>
+			<set name="wisdom">8</set>
+			<set name="charisma">7</set>
+            <set name="ac">{{companion:ac}} (natural armor)</set>
+			<set name="hp">{{companion:hp:max}}</set>
+			<set name="speed">10 ft., fly 80 ft.</set>
+			<set name="immunities">fire, poison, psychic</set>
+			<set name="conditionImmunities">charmed, poisoned</set>
+			<set name="saves">Str +{{companion:save}}, Dex +{{companion:save}}, Con +{{companion:save}}, Int +{{companion:intsave}}, Wis +{{companion:wissave}}, Cha +{{companion:chasave}}</set>
+			<set name="skills">Perception +3</set>
+			<set name="senses">darkvision 60 ft., passive Perception 13</set>
+			<set name="languages">understands the languages you speak</set>
+			<set name="type">Construct</set>
+			<set name="size">Tiny</set>
+			<set name="alignment">unaligned</set>
+			<set name="challenge">1/2</set>
+			<set name="traits">ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_KEEN_SIGHT,ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_IMMUTABLE_FORM,ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_AUTOMATED_HELPER,ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_DISTRACTING_NUISANCE</set>
+			<set name="actions">ID_AW_OOTD_COMPANION_ACTION_STIMFAY_TALONS,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PINION_STORM,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PIERCING_SCREECH</set>
+			<set name="reactions" />
+		</setters>
+		<rules>
+			<stat name="companion:ac" value="13" />
+            <stat name="companion:ac" value="proficiency" level="11" />
+			<stat name="companion:hp:max" value="15" />
+            <stat name="companion:hp:max" value="15" level="11" />
+			<stat name="companion:hp:max" value="level:ranger" />
+            <stat name="companion:speed" value="10" />
+            <stat name="companion:attack" value="proficiency" />
+			<stat name="companion:damage" value="proficiency" />
+            <stat name="companion:save" value="proficiency" />
+            <stat name="companion:intsave" value="-2" />
+            <stat name="companion:intsave" value="proficiency" />
+            <stat name="companion:wissave" value="-1" />
+            <stat name="companion:wissave" value="proficiency" />
+            <stat name="companion:chasave" value="-2" />
+            <stat name="companion:chasave" value="proficiency" />
+		</rules>
+	</element>
+
+    <element name="Keen Sight" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_KEEN_SIGHT">
+		<description>
+			<p>The stimfay has advantage on Wisdom (Perception) checks that rely on sight.</p>
+		</description>
+		<sheet>
+			<description>The stimfay has advantage on Wisdom (Perception) checks that rely on sight.</description>
+		</sheet>
+	</element>
+    <element name="Immutable Form" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_IMMUTABLE_FORM">
+		<description>
+			<p>The stimfay is immune to any spell or effect that would alter its form.</p>
+		</description>
+		<sheet>
+			<description>The stimfay is immune to any spell or effect that would alter its form.</description>
+		</sheet>
+	</element>
+    <element name="Automated Helper" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_AUTOMATED_HELPER">
+		<description>
+			<p>The stimfay can carry a single potion and administer it to any willing creature as an action. Additionally, the stimfay can use a bonus action to stabilize a dying creature that it can touch.</p>
+		</description>
+		<sheet>
+			<description>The stimfay can carry a single potion and administer it to any willing creature as an action. Additionally, the stimfay can use a bonus action to stabilize a dying creature that it can touch.</description>
+		</sheet>
+	</element>
+    <element name="Distracting Nuisance" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_DISTRACTING_NUISANCE">
+		<description>
+			<p>When the stimfay successfully hits a creature with its talons, that creature cannot make opportunity attacks until the beginning of its next turn.</p>
+		</description>
+		<sheet>
+			<description>When the stimfay successfully hits a creature with its talons, that creature cannot make opportunity attacks until the beginning of its next turn.</description>
+		</sheet>
+	</element>
+
+    <element name="Talons" type="Companion Action" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_ACTION_STIMFAY_TALONS">
+		<description>
+			<p>Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d6 slashing damage.</p>
+		</description>
+		<sheet>
+			<description level="3">Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1d6 slashing damage.</description>
+            <description level="11">Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 2d6 slashing damage (magical).</description>
+		</sheet>
+        <!--<rules>
+            <stat name="stimfay:attack" value="4" />
+            <stat name="stimfay:attack" value="proficiency" />
+            <stat name="stimfay:attackbonus" value="proficiency" />
+        </rules>-->
+	</element>
+    <element name="Pinion Storm" type="Companion Action" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PINION_STORM">
+		<description>
+			<p>Ranged Weapon Attack: +4 to hit, range 60 ft., one target. Hit: 1d6 piercing damage.</p>
+		</description>
+		<sheet>
+			<description level="3">Ranged Weapon Attack: +4 to hit, range 60 ft., one target. Hit: 1d6 piercing damage.</description>
+            <description level="11">Ranged Weapon Attack: +4 to hit, range 60 ft., one target. Hit: 2d6 piercing damage (magical).</description>
+		</sheet>
+        <!--<rules>
+            <stat name="stimfay:attack" value="4" />
+            <stat name="stimfay:attack" value="proficiency" />
+            <stat name="stimfay:attackbonus" value="proficiency" />
+        </rules>-->
+	</element>
+    <element name="Piercing Screech" type="Companion Action" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PIERCING_SCREECH">
+		<description>
+			<p>The stimfay emits an ear-splitting cry directed at one creature of your choice. The target must succeed on a DC 10 Constitution saving throw or else it takes 1d6 psychic damage and is deafened until the beginning of the stimfay’s next turn.</p>
+		</description>
+		<sheet>
+			<description level="3">The stimfay emits an ear-splitting cry directed at one creature of your choice. The target must succeed on a DC 10 Constitution saving throw or else it takes 1d6 psychic damage and is deafened until the beginning of the stimfay’s next turn.</description>
+            <description level="11">The stimfay emits an ear-splitting cry directed at one creature of your choice. The target must succeed on a DC 10 Constitution saving throw or else it takes 2d6 psychic damage and is deafened until the beginning of the stimfay’s next turn.</description>
+		</sheet>
+        <!--<rules>
+            <stat name="stimfay:dc" value="10" />
+            <stat name="stimfay:dc" value="proficiency" />
+            <stat name="stimfay:attackbonus" value="proficiency" />
+        </rules>-->
+	</element>
+
+    <element name="Amazonian Battlecry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY">
+        <description>
+            <p>At 3rd level, you gain the ability to enter the legendary frenzy of the Amazons by shouting your signature battlecry. On your turn, you can use a bonus action to shout your battlecry and enter a frenzy. Your frenzy lasts for 1 minute and grants you the following benefits. It ends after you take damage—or when you are knocked unconscious.</p>
+            <ul>
+                <li>You have advantage on attacks against creatures of your favored enemy type.</li>
+                <li>You have resistance to bludgeoning, piercing, and slashing damage.</li>
+                <li>You have advantage on saving throws against being frightened or paralyzed.</li>
+             </ul>
+            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain any expended uses when you finish a long rest.</p>
+        </description>
+        <sheet>
+            <description action="Bonus Action" usage="{{wisdom:modifier}}/Long Rest">You enter a frenzy that lasts for 1 minute or until you take damage or are knocked unconscious. While in this frenzy, you have advantage on attacks against creatures of your favored enemy type, esistance to bludgeoning, piercing, and slashing damage and advantage on saving throws against being frightened or paralyzed.</description>
+        </sheet>
+    </element>
+
+    <element name="Bracer Reflection" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION">
+        <description>
+            <p>Starting at 5th level, you've learned to reflect attacks with your bracers. Whenever you would be hit by an attack, you may use your reaction to shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn. You may use this feature a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a short or long rest.</p>
+        </description>
+        <sheet>
+            <description action="Reaction" usage="{{bracer reflection:uses}}/Short Rest">If you would be hit by an attack, shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn.</description>
+        </sheet>
+        <rules>
+            <stat name="bracer reflection:uses" value="1" bonus="base" />
+            <stat name="bracer reflection:uses" value="wisdom:modifier" bonus="base" />
+        </rules>
+    </element>
+
+    <element name="Chakram Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE">
+        <description>
+            <p>Starting at 7th level, you’ve learned the famous Amazonian technique of ricocheting your chakram to hit multiple targets. You can also throw it at targets that are not in your line of sight, such as around corners.</p>
+            <p class="indent">You can use your action to make a ranged attack with your chakram against one target. If your attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</p>
+        </description>
+        <sheet>
+            <description>When you use your action to make a ranged attack with your chakram against one target and the attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</description>
+        </sheet>
+    </element>
+
+    <element name="Improved Falconry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY">
+        <description>
+            <p>At 11th level, your stimfay matures. It gains a bonus to its AC equal to your proficiency bonus, and it now has hit points equal to 30 + your ranger level. The damage dice for its Talons, Pinion Storm, and Piercing Screech increase to 2d6, and its attacks are now magical.</p>
+            <p class="indent">Additionally, any time you would take damage from an attack or an effect that you can see, you may use your reaction to have your stimfay intercept the attack or effect and take the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</p>
+        </description>
+        <sheet>
+            <description action="Reaction">If you would take damage from an attack or an effect that you can see, your stimfay takes the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</description>
+        </sheet>
+        <rules />
+    </element>
+
+    <element name="Pressure Points" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS">
+        <description>
+            <p>Starting at 15th level, you know how to attack pressure points in your opponent’s body that will cut off the blood supply to their brain. On your turn, you may use a bonus action to make a special melee attack against one creature. If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds. You may use this ability a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
+        </description>
+        <sheet>
+            <description action="Bonus Action" usage="{{wisdom:modifier}}/Short Rest">Make a melee attack against one creature (using any weapon). If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds.</description>
+        </sheet>
+        <rules />
+    </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
@@ -32,7 +32,7 @@
         </rules>
     </element>
 
-    <element name="Amzaonian Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC">
+    <element name="Amazonian Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_MAGIC">
         <description>
             <p>Starting when you swear your oath at 3rd level, you gain Oath Spells at the listed levels and always have them prepared.</p>       
             <h5>Amazonian Spells</h5>
@@ -72,6 +72,64 @@
         </rules>
     </element>
 
+    <element name="Amazonian Battlecry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY">
+        <description>
+            <p>At 3rd level, you gain the ability to enter the legendary frenzy of the Amazons by shouting your signature battlecry. On your turn, you can use a bonus action to shout your battlecry and enter a frenzy. Your frenzy lasts for 1 minute and grants you the following benefits. It ends after you take damage—or when you are knocked unconscious.</p>
+            <ul>
+                <li>You have advantage on attacks against creatures of your favored enemy type.</li>
+                <li>You have resistance to bludgeoning, piercing, and slashing damage.</li>
+                <li>You have advantage on saving throws against being frightened or paralyzed.</li>
+             </ul>
+            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain any expended uses when you finish a long rest.</p>
+        </description>
+        <sheet>
+            <description action="Bonus Action" usage="{{wisdom:modifier}}/Long Rest">You enter a frenzy that lasts for 1 minute or until you take damage or are knocked unconscious. While in this frenzy, you have advantage on attacks against creatures of your favored enemy type, esistance to bludgeoning, piercing, and slashing damage and advantage on saving throws against being frightened or paralyzed.</description>
+        </sheet>
+    </element>
+
+    <element name="Bracer Reflection" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION">
+        <description>
+            <p>Starting at 5th level, you've learned to reflect attacks with your bracers. Whenever you would be hit by an attack, you may use your reaction to shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn. You may use this feature a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a short or long rest.</p>
+        </description>
+        <sheet>
+            <description action="Reaction" usage="{{bracer reflection:uses}}/Short Rest">If you would be hit by an attack, shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn.</description>
+        </sheet>
+        <rules>
+            <stat name="bracer reflection:uses" value="1" bonus="base" />
+            <stat name="bracer reflection:uses" value="wisdom:modifier" bonus="base" />
+        </rules>
+    </element>
+
+    <element name="Chakram Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE">
+        <description>
+            <p>Starting at 7th level, you’ve learned the famous Amazonian technique of ricocheting your chakram to hit multiple targets. You can also throw it at targets that are not in your line of sight, such as around corners.</p>
+            <p class="indent">You can use your action to make a ranged attack with your chakram against one target. If your attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</p>
+        </description>
+        <sheet>
+            <description>When you use your action to make a ranged attack with your chakram against one target and the attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</description>
+        </sheet>
+    </element>
+
+    <element name="Improved Falconry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY">
+        <description>
+            <p>At 11th level, your stimfay matures. It gains a bonus to its AC equal to your proficiency bonus, and it now has hit points equal to 30 + your ranger level. The damage dice for its Talons, Pinion Storm, and Piercing Screech increase to 2d6, and its attacks are now magical.</p>
+            <p class="indent">Additionally, any time you would take damage from an attack or an effect that you can see, you may use your reaction to have your stimfay intercept the attack or effect and take the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</p>
+        </description>
+        <sheet>
+            <description action="Reaction">If you would take damage from an attack or an effect that you can see, your stimfay takes the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</description>
+        </sheet>
+    </element>
+
+    <element name="Pressure Points" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS">
+        <description>
+            <p>Starting at 15th level, you know how to attack pressure points in your opponent’s body that will cut off the blood supply to their brain. On your turn, you may use a bonus action to make a special melee attack against one creature. If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds. You may use this ability a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
+        </description>
+        <sheet>
+            <description action="Bonus Action" usage="{{wisdom:modifier}}/Short Rest">Make a melee attack against one creature (using any weapon). If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds.</description>
+        </sheet>
+    </element>
+
+    <!-- Companion -->
     <element name="Stimfay" type="Companion" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_RANGER_AMAZONIAN_STIMFAY">
 		<supports>Stimfay Companion</supports>
 		<description>
@@ -195,63 +253,4 @@
             <stat name="stimfay:attackbonus" value="proficiency" />
         </rules>-->
 	</element>
-
-    <element name="Amazonian Battlecry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_AMAZONIAN_BATTLECRY">
-        <description>
-            <p>At 3rd level, you gain the ability to enter the legendary frenzy of the Amazons by shouting your signature battlecry. On your turn, you can use a bonus action to shout your battlecry and enter a frenzy. Your frenzy lasts for 1 minute and grants you the following benefits. It ends after you take damage—or when you are knocked unconscious.</p>
-            <ul>
-                <li>You have advantage on attacks against creatures of your favored enemy type.</li>
-                <li>You have resistance to bludgeoning, piercing, and slashing damage.</li>
-                <li>You have advantage on saving throws against being frightened or paralyzed.</li>
-             </ul>
-            <p class="indent">You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain any expended uses when you finish a long rest.</p>
-        </description>
-        <sheet>
-            <description action="Bonus Action" usage="{{wisdom:modifier}}/Long Rest">You enter a frenzy that lasts for 1 minute or until you take damage or are knocked unconscious. While in this frenzy, you have advantage on attacks against creatures of your favored enemy type, esistance to bludgeoning, piercing, and slashing damage and advantage on saving throws against being frightened or paralyzed.</description>
-        </sheet>
-    </element>
-
-    <element name="Bracer Reflection" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_BRACER_REFLECTION">
-        <description>
-            <p>Starting at 5th level, you've learned to reflect attacks with your bracers. Whenever you would be hit by an attack, you may use your reaction to shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn. You may use this feature a number of times equal to your Wisdom modifier (a minimum of once), and you regain all expended uses when you finish a short or long rest.</p>
-        </description>
-        <sheet>
-            <description action="Reaction" usage="{{bracer reflection:uses}}/Short Rest">If you would be hit by an attack, shield yourself with your bracers. You gain a +5 bonus to AC against all attacks, including the attack that provoked this reaction, until the beginning of your next turn.</description>
-        </sheet>
-        <rules>
-            <stat name="bracer reflection:uses" value="1" bonus="base" />
-            <stat name="bracer reflection:uses" value="wisdom:modifier" bonus="base" />
-        </rules>
-    </element>
-
-    <element name="Chakram Technique" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_CHAKRAM_TECHNIQUE">
-        <description>
-            <p>Starting at 7th level, you’ve learned the famous Amazonian technique of ricocheting your chakram to hit multiple targets. You can also throw it at targets that are not in your line of sight, such as around corners.</p>
-            <p class="indent">You can use your action to make a ranged attack with your chakram against one target. If your attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</p>
-        </description>
-        <sheet>
-            <description>When you use your action to make a ranged attack with your chakram against one target and the attack hits, then any number of additional creatures of your choice within 10 feet of that target must make a Dexterity saving throw using your spell save DC. Each creature that fails the save takes the same amount of damage as your first target.</description>
-        </sheet>
-    </element>
-
-    <element name="Improved Falconry" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_IMPROVED_FALCONRY">
-        <description>
-            <p>At 11th level, your stimfay matures. It gains a bonus to its AC equal to your proficiency bonus, and it now has hit points equal to 30 + your ranger level. The damage dice for its Talons, Pinion Storm, and Piercing Screech increase to 2d6, and its attacks are now magical.</p>
-            <p class="indent">Additionally, any time you would take damage from an attack or an effect that you can see, you may use your reaction to have your stimfay intercept the attack or effect and take the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</p>
-        </description>
-        <sheet>
-            <description action="Reaction">If you would take damage from an attack or an effect that you can see, your stimfay takes the damage instead of you. Your stimfay must be functional and ready to assist you in order to use this ability, and it must be located within 60 feet of you.</description>
-        </sheet>
-        <rules />
-    </element>
-
-    <element name="Pressure Points" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_RANGER_AMAZONIAN_PRESSURE_POINTS">
-        <description>
-            <p>Starting at 15th level, you know how to attack pressure points in your opponent’s body that will cut off the blood supply to their brain. On your turn, you may use a bonus action to make a special melee attack against one creature. If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds. You may use this ability a number of times equal to your Wisdom modifier, and you regain all expended uses after a short or long rest.</p>
-        </description>
-        <sheet>
-            <description action="Bonus Action" usage="{{wisdom:modifier}}/Short Rest">Make a melee attack against one creature (using any weapon). If the attack hits, the creature must make a Constitution saving throw versus your spell save DC. On a failure, the creature is paralyzed for 1 minute or until you use a bonus action to touch them and reverse the effect. At the end of each of the creature’s turns, it repeats the saving throw and the effect ends if it succeeds.</description>
-        </sheet>
-        <rules />
-    </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-ranger-amazonian.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-ranger-amazonian.xml" />
 		</update>
@@ -142,12 +141,12 @@
 			<set name="intelligence">6</set>
 			<set name="wisdom">8</set>
 			<set name="charisma">7</set>
-            <set name="ac">{{companion:ac}} (natural armor)</set>
-			<set name="hp">{{companion:hp:max}}</set>
+            <set name="ac">13 (natural armor)</set>
+			<set name="hp">15</set>
 			<set name="speed">10 ft., fly 80 ft.</set>
 			<set name="immunities">fire, poison, psychic</set>
 			<set name="conditionImmunities">charmed, poisoned</set>
-			<set name="saves">Str +{{companion:save}}, Dex +{{companion:save}}, Con +{{companion:save}}, Int +{{companion:intsave}}, Wis +{{companion:wissave}}, Cha +{{companion:chasave}}</set>
+			<set name="saves" />
 			<set name="skills">Perception +3</set>
 			<set name="senses">darkvision 60 ft., passive Perception 13</set>
 			<set name="languages">understands the languages you speak</set>
@@ -159,6 +158,7 @@
 			<set name="actions">ID_AW_OOTD_COMPANION_ACTION_STIMFAY_TALONS,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PINION_STORM,ID_AW_OOTD_COMPANION_ACTION_STIMFAY_PIERCING_SCREECH</set>
 			<set name="reactions" />
 		</setters>
+        <!--
 		<rules>
 			<stat name="companion:ac" value="13" />
             <stat name="companion:ac" value="proficiency" level="11" />
@@ -176,6 +176,7 @@
             <stat name="companion:chasave" value="-2" />
             <stat name="companion:chasave" value="proficiency" />
 		</rules>
+        -->
 	</element>
 
     <element name="Keen Sight" type="Companion Trait" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_COMPANION_TRAIT_STIMFAY_KEEN_SIGHT">

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
@@ -72,6 +72,16 @@
 		</rules>
     </element>
 
+    <element name="Legendary Cunning" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING">
+        <description>
+            <p>Starting at 17th level, you are able to instantly assess every opportunity to seize the upper hand in combat. Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</p>
+        </description>
+        <sheet>
+            <description>Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</description>
+        </sheet>
+    </element>
+
+    <!-- subfeatures -->
     <element name="Deep Breath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_DEEP_BREATH">
         <description />
         <sheet>
@@ -81,15 +91,5 @@
             <stat name="deep breath:uses" value="0" bonus="base" />
 			<stat name="deep breath:uses" value="charisma:modifier" bonus="base" />
         </rules>
-    </element>
-
-    <element name="Legendary Cunning" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING">
-        <description>
-            <p>Starting at 17th level, you are able to instantly assess every opportunity to seize the upper hand in combat. Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</p>
-        </description>
-        <sheet>
-            <description>Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</description>
-        </sheet>
-        <rules />
     </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
@@ -28,7 +28,6 @@
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING" level="17"/>
         </rules>
     </element>
-
     <element name="Vagrant Soldier" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_VAGRANT_SOLDIER">
         <description>
             <p>Despite your roguish demeanor, you have all the training of a common soldier. When you choose this archetype at 3rd level, you gain proficiency with shields. Additionally, spears and tridents count as finesse weapons for you.</p>
@@ -40,16 +39,14 @@
             <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" />
         </rules>
     </element>
-
     <element name="Clever as the Gods" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_CLEVER_AS_THE_GODS">
         <description>
             <p>Starting at 3rd level, you are rarely outwitted on the field of battle. On your turn, you may use your bonus action to devise a clever plan to trick an enemy. Choose one creature that you can see. Make a Charisma (Deception) roll contested by that creature’s Wisdom (Insight). If you win the contest, you and your allies have advantage on attacks against that creature until the beginning of your next turn. This feature cannot be used on the same creature more than once per combat encounter.</p>
         </description>
         <sheet>
-            <description action="Bonus Action">Choose one creature that you can see. Make a Charisma (Deception) roll contested by that creature’s Wisdom (Insight). If you win the contest, you and your allies have advantage on attacks against that creature until the beginning of your next turn. This feature cannot be used on the same creature more than once per combat encounter.</description>
+            <description action="Bonus Action">Choose one creature that you can see. Make a Deception roll contested by that creature’s Insight. If you win the contest, you and your allies have advantage on attacks against that creature until the beginning of your next turn. This feature cannot be used on the same creature more than once per combat encounter.</description>
         </sheet>
     </element>
-
     <element name="Notorious Trickster" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_NOTORIOUS_TRICKSTER">
         <description>
             <p>Starting at 9th level, you are famed for your cleverness, to the point where intelligent enemies are extremely wary of you. Creatures who are aware of your presence but cannot see you become too distracted to perform opportunity attacks until they can see you again. Additionally, when you hit a creature with a Sneak Attack, if that creature is concentrating on a spell, they have disadvantage on the roll to maintain concentration.</p>
@@ -58,19 +55,17 @@
             <description>Creatures who are aware of your presence but cannot see you become too distracted to perform opportunity attacks until they can see you again. Additionally, when you hit a creature with a Sneak Attack, if that creature is concentrating on a spell, they have disadvantage on the roll to maintain concentration.</description>
         </sheet>
     </element>
-
     <element name="Tenacious Survivor" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_TENACIOUS_SURVIVOR">
         <description>
             <p>At 13th level, you’ve survived through so many ordeals that you face each new challenge with grim determination. You can add your Charisma bonus to your initiative rolls. Also, at the beginning of your first turn in combat, you may use a bonus action to take a deep breath and regain hit points equal to your rogue level. You may use this feature a number of times equal to your Charisma modifier, and you regain any expended uses when you finish a short or long rest.</p>
         </description>
-        <sheet>
-            <description>You can add your Charisma bonus to your initiative rolls.</description>
+        <sheet action="Bonus Action" usage="{{charisma:modifier}}/Short Rest">
+            <description>At the beginning of your first turn in combat, you may take a deep breath and regain {{level:rogue}} hp.</description>
         </sheet>
 		<rules>
-			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_DEEP_BREATH" />
+            <stat name="initiative:misc" value="charisma:modifier" />
 		</rules>
-    </element>
-
+    </element>    
     <element name="Legendary Cunning" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING">
         <description>
             <p>Starting at 17th level, you are able to instantly assess every opportunity to seize the upper hand in combat. Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</p>
@@ -78,17 +73,5 @@
         <sheet>
             <description>Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</description>
         </sheet>
-    </element>
-
-    <!-- subfeatures -->
-    <element name="Deep Breath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_DEEP_BREATH">
-        <description />
-        <sheet>
-            <description action="Bonus Action" usage="{{charisma:modifier}}/Short Rest">At the beginning of your first turn in combat, regain hit points equal to your rogue level.</description>
-        </sheet>
-        <rules>
-            <stat name="deep breath:uses" value="0" bonus="base" />
-			<stat name="deep breath:uses" value="charisma:modifier" bonus="base" />
-        </rules>
     </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-rogue-odyssean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml" />
 		</update>
@@ -18,8 +17,8 @@
             <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_TENACIOUS_SURVIVOR" />
             <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING" />
         </description>
-        <sheet>
-            <description>Combines stealth with a knack for survival</description>
+        <sheet display="false">
+            <description>Odysseans are legendary tricksters who at first glance seem like common soldiers.</description>
         </sheet>
         <rules>
             <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_VAGRANT_SOLDIER" level="3"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-rogue-odyssean.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-rogue-odyssean.xml" />
+		</update>
+	</info>
+    <element name="Odyssean" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_ROGUE_ODYSSEAN">
+        <supports>Roguish Archetype</supports>
+        <description>
+            <p>Odysseans are legendary tricksters who at first glance seem like common soldiers. They carry spears and shields like any rank-and-file hoplite, but rather than moving in strict formations or honing their discipline, Odysseans hone their minds. When two armies smash together, shields bursting under the strain of a perfect phalanx, the Odyssean is the soldier who stands back and searches for weaknesses in the enemy’s defenses. Even when badly outnumbered, they may find a way to exploit conditions on the battlefield to turn the tide in the favor of their allies.</p>
+            <p class="indent">Soldiers who exhibit such a sharp mind quickly grow in notoriety and fame, but being famed for your cleverness is a double-edged sword. Odysseans are often drawn into conflicts that take them far from home, where monsters and other dangers are a constant threat. Such harrowing odysseys are the namesake of the Odyssean, who may be forced to survive several such journeys in their lifetime.</p>
+            <p class="indent">As an Odyssean rogue, you have a quick mind and you can intuit the strengths of your companions. You enjoy using your intelligence to trick your enemies and impress your friends. However, you know that you must never let your mind grow dull, for when the time comes that you are again flung into the wilderness, it will be your wits alone that save you from a gruesome death.</p>
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_VAGRANT_SOLDIER" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_CLEVER_AS_THE_GODS" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_NOTORIOUS_TRICKSTER" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_TENACIOUS_SURVIVOR" />
+            <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING" />
+        </description>
+        <sheet>
+            <description>Combines stealth with a knack for survival</description>
+        </sheet>
+        <rules>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_VAGRANT_SOLDIER" level="3"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_CLEVER_AS_THE_GODS" level="3"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_NOTORIOUS_TRICKSTER" level="9"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_TENACIOUS_SURVIVOR" level="13"/>
+            <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING" level="17"/>
+        </rules>
+    </element>
+
+    <element name="Vagrant Soldier" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_VAGRANT_SOLDIER">
+        <description>
+            <p>Despite your roguish demeanor, you have all the training of a common soldier. When you choose this archetype at 3rd level, you gain proficiency with shields. Additionally, spears and tridents count as finesse weapons for you.</p>
+        </description>
+        <sheet>
+            <description>Spears and tridents count as finesse weapons for you.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_ARMOR_PROFICIENCY_SHIELDS" />
+        </rules>
+    </element>
+
+    <element name="Clever as the Gods" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_CLEVER_AS_THE_GODS">
+        <description>
+            <p>Starting at 3rd level, you are rarely outwitted on the field of battle. On your turn, you may use your bonus action to devise a clever plan to trick an enemy. Choose one creature that you can see. Make a Charisma (Deception) roll contested by that creature’s Wisdom (Insight). If you win the contest, you and your allies have advantage on attacks against that creature until the beginning of your next turn. This feature cannot be used on the same creature more than once per combat encounter.</p>
+        </description>
+        <sheet>
+            <description action="Bonus Action">Choose one creature that you can see. Make a Charisma (Deception) roll contested by that creature’s Wisdom (Insight). If you win the contest, you and your allies have advantage on attacks against that creature until the beginning of your next turn. This feature cannot be used on the same creature more than once per combat encounter.</description>
+        </sheet>
+    </element>
+
+    <element name="Notorious Trickster" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_NOTORIOUS_TRICKSTER">
+        <description>
+            <p>Starting at 9th level, you are famed for your cleverness, to the point where intelligent enemies are extremely wary of you. Creatures who are aware of your presence but cannot see you become too distracted to perform opportunity attacks until they can see you again. Additionally, when you hit a creature with a Sneak Attack, if that creature is concentrating on a spell, they have disadvantage on the roll to maintain concentration.</p>
+        </description>
+        <sheet>
+            <description>Creatures who are aware of your presence but cannot see you become too distracted to perform opportunity attacks until they can see you again. Additionally, when you hit a creature with a Sneak Attack, if that creature is concentrating on a spell, they have disadvantage on the roll to maintain concentration.</description>
+        </sheet>
+    </element>
+
+    <element name="Tenacious Survivor" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_TENACIOUS_SURVIVOR">
+        <description>
+            <p>At 13th level, you’ve survived through so many ordeals that you face each new challenge with grim determination. You can add your Charisma bonus to your initiative rolls. Also, at the beginning of your first turn in combat, you may use a bonus action to take a deep breath and regain hit points equal to your rogue level. You may use this feature a number of times equal to your Charisma modifier, and you regain any expended uses when you finish a short or long rest.</p>
+        </description>
+        <sheet>
+            <description>You can add your Charisma bonus to your initiative rolls.</description>
+        </sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_DEEP_BREATH" />
+		</rules>
+    </element>
+
+    <element name="Deep Breath" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_DEEP_BREATH">
+        <description />
+        <sheet>
+            <description action="Bonus Action" usage="{{charisma:modifier}}/Short Rest">At the beginning of your first turn in combat, regain hit points equal to your rogue level.</description>
+        </sheet>
+        <rules>
+            <stat name="deep breath:uses" value="0" bonus="base" />
+			<stat name="deep breath:uses" value="charisma:modifier" bonus="base" />
+        </rules>
+    </element>
+
+    <element name="Legendary Cunning" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ODYSSEAN_LEGENDARY_CUNNING">
+        <description>
+            <p>Starting at 17th level, you are able to instantly assess every opportunity to seize the upper hand in combat. Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</p>
+        </description>
+        <sheet>
+            <description>Whenever any of your allies makes an opportunity attack against a creature, you may choose to make a ranged attack against that same creature with advantage.</description>
+        </sheet>
+        <rules />
+    </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
@@ -55,7 +55,47 @@
 		</rules>
 	</element>
 
-    <element name="Death domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DEATH" >
+	<element name="Inherited Strength" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH">
+		<description>
+			<p>Starting at 1st level, your godly lineage bestows you with extraordinary strength for someone without martial training. You are proficient in Strength saving throws. Additionally, you may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</p>
+		</description>
+		<sheet>
+			<description>You may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</description>
+		</sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_STRENGTH" />
+        </rules>
+	</element>
+
+	<element name="Empowered Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC">
+		<description>
+			<p>Starting at 6th level, echoes of divine power flow through your spells. When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1. For example, if you use a 5th-level spell slot to cast <i>fireball</i> as a 5th-level spell, you may spend 1 sorcery point to cast the spell at 6th level instead.</p>
+		</description>
+		<sheet>
+			<description>When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1.</description>
+		</sheet>
+	</element>
+
+	<element name="Divine Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE">
+		<description>
+			<p>Starting at 14th level, your divine blood allows you to shrug off effects that would destroy mere mortals. When you fail a saving throw, you may choose to succeed instead. You may use this feature once, and you regain the ability to do so after completing a long rest.</p>
+		</description>
+		<sheet>
+			<description usage="1/Long Rest">When you fail a saving throw, you may choose to succeed instead.</description>
+		</sheet>
+	</element>
+
+	<element name="Ascendant Sorcery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY">
+		<description>
+			<p>Starting at 18th level, your power has begun to rival your divine ancestor’s. When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</p>
+		</description>
+		<sheet>
+			<description>When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</description>
+		</sheet>
+	</element>
+
+	<!-- Godly Ancestor options -->
+	<element name="Death domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DEATH" >
         <supports>Godly Ancestor</supports>
         <description />
 		<sheet>
@@ -143,43 +183,4 @@
 			<grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" />
         </rules>
     </element>
-
-	<element name="Inherited Strength" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH">
-		<description>
-			<p>Starting at 1st level, your godly lineage bestows you with extraordinary strength for someone without martial training. You are proficient in Strength saving throws. Additionally, you may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</p>
-		</description>
-		<sheet>
-			<description>You may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</description>
-		</sheet>
-        <rules>
-            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_STRENGTH" />
-        </rules>
-	</element>
-
-	<element name="Empowered Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC">
-		<description>
-			<p>Starting at 6th level, echoes of divine power flow through your spells. When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1. For example, if you use a 5th-level spell slot to cast <i>fireball</i> as a 5th-level spell, you may spend 1 sorcery point to cast the spell at 6th level instead.</p>
-		</description>
-		<sheet>
-			<description>When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1.</description>
-		</sheet>
-	</element>
-
-	<element name="Divine Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE">
-		<description>
-			<p>Starting at 14th level, your divine blood allows you to shrug off effects that would destroy mere mortals. When you fail a saving throw, you may choose to succeed instead. You may use this feature once, and you regain the ability to do so after completing a long rest.</p>
-		</description>
-		<sheet>
-			<description usage="1/Long Rest">When you fail a saving throw, you may choose to succeed instead.</description>
-		</sheet>
-	</element>
-
-	<element name="Ascendant Sorcery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY">
-		<description>
-			<p>Starting at 18th level, your power has begun to rival your divine ancestor’s. When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</p>
-		</description>
-		<sheet>
-			<description>When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</description>
-		</sheet>
-	</element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-sorcerer-demigod.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml" />
+		</update>
+	</info>
+	<element name="Demigod" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_SORCERER_DEMIGOD">
+		<supports>Sorcerous Origin</supports>
+		<description>
+			<p>Your magic springs from the divine blood that flows through your veins. The gods have often been known to consort with mortals, and such unions sometimes produce half-divine offspring. These individuals are called demigods, and many of them are born with a powerful aptitude for magic.</p>
+			<p class="indent">Demigods exhibit powers that are related to the domain of their godly ancestor, but their magic is not constrained by this association. Rather, they may channel the power in their blood to improve the efficacy of any spell, regardless of its type. Additionally, the divine power that courses through their blood makes demigods impressive specimens of both physical fitness and beauty.</p>
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_GODLY_ANCESTOR" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY" />
+		</description>
+		<sheet>
+			<description>Sometimes the spark of magic that fuels a sorcerer comes from a divine source that glimmers within the soul.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_GODLY_ANCESTOR" level="1" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH" level="1" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC" level="6" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE" level="14" />
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY" level="18" />
+		</rules>
+	</element>
+
+	<element name="Godly Ancestor" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_GODLY_ANCESTOR">
+		<description>
+			<p>Starting at 1st level, choose the divine domain of your godly ancestor from the following list. You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<p class="indent">Additionally, whenever you make a Charisma check when interacting with gods or celestials, your proficiency bonus is doubled if it applies to the check.</p>
+			<table>
+				<thead>
+					<tr><td>Divine domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
+		<sheet>
+            <description>Whenever you make a Charisma check when interacting with gods or celestials, your proficiency bonus is doubled if it applies to the check.</description>
+        </sheet>
+		<rules>
+			<select type="Archetype Feature" name="Ancestor's Domain" supports="Godly Ancestor" />
+		</rules>
+	</element>
+
+    <element name="Death domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DEATH" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast bane or ray of sickness without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_BANE" />
+			<grant type="Spell" id="ID_PHB_SPELL_RAY_OF_SICKNESS" />
+        </rules>
+    </element>
+    <element name="Knowledge domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_KNOWLEDGE" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast command or guiding bolt without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_COMMAND" />
+			<grant type="Spell" id="ID_PHB_SPELL_GUIDING_BOLT" />
+        </rules>
+    </element>
+    <element name="Life domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIFE" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast cure wounds or bless without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_CURE_WOUNDS" />
+			<grant type="Spell" id="ID_PHB_SPELL_BLESS" />
+        </rules>
+    </element>
+    <element name="Nature domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_NATURE" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast entangle or healing word without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_ENTANGLE" />
+			<grant type="Spell" id="ID_PHB_SPELL_HEALING_WORD" />
+        </rules>
+    </element>
+    <element name="Light domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIGHT" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast burning hands or faerie fire without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_BURNING_HANDS" />
+			<grant type="Spell" id="ID_PHB_SPELL_FAERIE_FIRE" />
+        </rules>
+    </element>
+    <element name="Tempest domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TEMPEST" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast fog cloud or thunderwave without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_FOG_CLOUD" />
+			<grant type="Spell" id="ID_PHB_SPELL_THUNDERWAVE" />
+        </rules>
+    </element>
+    <element name="Trickery domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TRICKERY" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast charm person or hideous laughter without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" />
+			<grant type="Spell" id="ID_PHB_SPELL_TASHAS_HIDEOUS_LAUGHTER" />
+        </rules>
+    </element>
+    <element name="War domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_WAR" >
+        <supports>Godly Ancestor</supports>
+        <description />
+		<sheet>
+            <description usage="1/Long Rest each">Cast shield of faith or thunderous smite without expending a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Spell" id="ID_PHB_SPELL_SHIELD_OF_FAITH" />
+			<grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" />
+        </rules>
+    </element>
+
+	<element name="Inherited Strength" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH">
+		<description>
+			<p>Starting at 1st level, your godly lineage bestows you with extraordinary strength for someone without martial training. You are proficient in Strength saving throws. Additionally, you may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</p>
+		</description>
+		<sheet>
+			<description>You may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</description>
+		</sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_STRENGTH" />
+        </rules>
+	</element>
+
+	<element name="Empowered Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC">
+		<description>
+			<p>Starting at 6th level, echoes of divine power flow through your spells. When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1. For example, if you use a 5th-level spell slot to cast <i>fireball</i> as a 5th-level spell, you may spend 1 sorcery point to cast the spell at 6th level instead.</p>
+		</description>
+		<sheet>
+			<description>When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1.</description>
+		</sheet>
+	</element>
+
+	<element name="Divine Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE">
+		<description>
+			<p>Starting at 14th level, your divine blood allows you to shrug off effects that would destroy mere mortals. When you fail a saving throw, you may choose to succeed instead. You may use this feature once, and you regain the ability to do so after completing a long rest.</p>
+		</description>
+		<sheet>
+			<description usage="1/Long Rest">When you fail a saving throw, you may choose to succeed instead.</description>
+		</sheet>
+	</element>
+
+	<element name="Ascendant Sorcery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY">
+		<description>
+			<p>Starting at 18th level, your power has begun to rival your divine ancestor’s. When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</p>
+		</description>
+		<sheet>
+			<description>When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</description>
+		</sheet>
+	</element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
 	<info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-sorcerer-demigod.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml" />
 		</update>
@@ -17,8 +16,8 @@
 			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE" />
 			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY" />
 		</description>
-		<sheet>
-			<description>Sometimes the spark of magic that fuels a sorcerer comes from a divine source that glimmers within the soul.</description>
+		<sheet display="false">
+			<description>Your magic springs from the divine blood that flows through your veins.</description>
 		</sheet>
 		<rules>
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_GODLY_ANCESTOR" level="1" />

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-sorcerer-demigod.xml
@@ -27,14 +27,14 @@
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY" level="18" />
 		</rules>
 	</element>
-
 	<element name="Godly Ancestor" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_GODLY_ANCESTOR">
 		<description>
 			<p>Starting at 1st level, choose the divine domain of your godly ancestor from the following list. You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
 			<p class="indent">Additionally, whenever you make a Charisma check when interacting with gods or celestials, your proficiency bonus is doubled if it applies to the check.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
 			<table>
 				<thead>
-					<tr><td>Divine domain</td><td>Spells</td></tr>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
 				</thead>
 				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
 				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
@@ -50,10 +50,9 @@
             <description>Whenever you make a Charisma check when interacting with gods or celestials, your proficiency bonus is doubled if it applies to the check.</description>
         </sheet>
 		<rules>
-			<select type="Archetype Feature" name="Ancestor's Domain" supports="Godly Ancestor" />
+			<select type="Archetype Feature" name="Divine Domain, Godly Ancestor" supports="Godly Ancestor Divine Domain" />
 		</rules>
 	</element>
-
 	<element name="Inherited Strength" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_INHERITED_STRENGTH">
 		<description>
 			<p>Starting at 1st level, your godly lineage bestows you with extraordinary strength for someone without martial training. You are proficient in Strength saving throws. Additionally, you may choose to add your Charisma modifier to melee attack and damage rolls instead of your Strength.</p>
@@ -65,7 +64,6 @@
             <grant type="Proficiency" id="ID_PROFICIENCY_SAVINGTHROW_STRENGTH" />
         </rules>
 	</element>
-
 	<element name="Empowered Magic" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_EMPOWERED_MAGIC">
 		<description>
 			<p>Starting at 6th level, echoes of divine power flow through your spells. When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1. For example, if you use a 5th-level spell slot to cast <i>fireball</i> as a 5th-level spell, you may spend 1 sorcery point to cast the spell at 6th level instead.</p>
@@ -74,7 +72,6 @@
 			<description>When you cast a spell, you may spend 1 sorcery point to increase the spell's level by 1. You cannot use this feature to increase a spell’s level by more than 1.</description>
 		</sheet>
 	</element>
-
 	<element name="Divine Resistance" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DIVINE_RESISTANCE">
 		<description>
 			<p>Starting at 14th level, your divine blood allows you to shrug off effects that would destroy mere mortals. When you fail a saving throw, you may choose to succeed instead. You may use this feature once, and you regain the ability to do so after completing a long rest.</p>
@@ -83,7 +80,6 @@
 			<description usage="1/Long Rest">When you fail a saving throw, you may choose to succeed instead.</description>
 		</sheet>
 	</element>
-
 	<element name="Ascendant Sorcery" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_ASCENDANT_SORCERY">
 		<description>
 			<p>Starting at 18th level, your power has begun to rival your divine ancestor’s. When you use the Empowered Magic feature, you may increase the spell’s level by more than 1. You must spend 1 sorcery point for each level that you add to the spell.</p>
@@ -94,92 +90,228 @@
 	</element>
 
 	<!-- Godly Ancestor options -->
-	<element name="Death domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DEATH" >
-        <supports>Godly Ancestor</supports>
-        <description />
+	<element name="Death Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_DEATH_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast bane or ray of sickness without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast bane or ray of sickness without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_BANE" />
-			<grant type="Spell" id="ID_PHB_SPELL_RAY_OF_SICKNESS" />
+            <grant type="Spell" id="ID_PHB_SPELL_BANE" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_RAY_OF_SICKNESS" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Knowledge domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_KNOWLEDGE" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Knowledge Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_KNOWLEDGE_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast command or guiding bolt without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast command or guiding bolt without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_COMMAND" />
-			<grant type="Spell" id="ID_PHB_SPELL_GUIDING_BOLT" />
+            <grant type="Spell" id="ID_PHB_SPELL_COMMAND" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_GUIDING_BOLT" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Life domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIFE" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Life Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIFE_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast cure wounds or bless without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast cure wounds or bless without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_CURE_WOUNDS" />
-			<grant type="Spell" id="ID_PHB_SPELL_BLESS" />
+            <grant type="Spell" id="ID_PHB_SPELL_CURE_WOUNDS" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_BLESS" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Nature domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_NATURE" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Nature Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_NATURE_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast entangle or healing word without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast entangle or healing word without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_ENTANGLE" />
-			<grant type="Spell" id="ID_PHB_SPELL_HEALING_WORD" />
+            <grant type="Spell" id="ID_PHB_SPELL_ENTANGLE" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_HEALING_WORD" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Light domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIGHT" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Light Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_LIGHT_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast burning hands or faerie fire without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast burning hands or faerie fire without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_BURNING_HANDS" />
-			<grant type="Spell" id="ID_PHB_SPELL_FAERIE_FIRE" />
+            <grant type="Spell" id="ID_PHB_SPELL_BURNING_HANDS" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_FAERIE_FIRE" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Tempest domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TEMPEST" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Tempest Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TEMPEST_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast fog cloud or thunderwave without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast fog cloud or thunderwave without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_FOG_CLOUD" />
-			<grant type="Spell" id="ID_PHB_SPELL_THUNDERWAVE" />
+            <grant type="Spell" id="ID_PHB_SPELL_FOG_CLOUD" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_THUNDERWAVE" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="Trickery domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TRICKERY" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="Trickery Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_TRICKERY_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast charm person or hideous laughter without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast charm person or hideous laughter without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" />
-			<grant type="Spell" id="ID_PHB_SPELL_TASHAS_HIDEOUS_LAUGHTER" />
+            <grant type="Spell" id="ID_PHB_SPELL_CHARM_PERSON" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_TASHAS_HIDEOUS_LAUGHTER" spellcasting="Sorcerer" />
         </rules>
     </element>
-    <element name="War domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_WAR" >
-        <supports>Godly Ancestor</supports>
-        <description />
+    <element name="War Domain" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_DEMIGOD_WAR_DOMAIN">
+		<compendium display="false" />
+        <supports>Godly Ancestor Divine Domain</supports>
+        <description>
+			<p>You can cast each of the associated spells once without using any spell slots, and you regain the ability to do so after completing a short or long rest.</p>
+			<h5 class="caption">DEMIGOD DOMAINS AND SPELLS</h5>
+			<table>
+				<thead>
+					<tr><td>Divine Domain</td><td>Spells</td></tr>
+				</thead>
+				<tr><td>Death</td><td><i>bane, ray of sickness</i></td></tr>
+				<tr><td>Knowledge</td><td><i>command, guiding bolt</i></td></tr>
+				<tr><td>Life</td><td><i>cure wounds, bless</i></td></tr>
+				<tr><td>Nature</td><td><i>entangle, healing word</i></td></tr>
+				<tr><td>Light</td><td><i>burning hands, faerie fire</i></td></tr>
+                <tr><td>Tempest</td><td><i>fog cloud, thunderwave</i></td></tr>
+                <tr><td>Trickery</td><td><i>charm person, hideous laughter</i></td></tr>
+                <tr><td>War</td><td><i>shield of faith, thunderous smite</i></td></tr>
+			</table>
+		</description>
 		<sheet>
-            <description usage="1/Long Rest each">Cast shield of faith or thunderous smite without expending a spell slot.</description>
+            <description usage="1/Short Rest">You can cast shield of faith or thunderous smite without expending a spell slot.</description>
         </sheet>
         <rules>
-            <grant type="Spell" id="ID_PHB_SPELL_SHIELD_OF_FAITH" />
-			<grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" />
+            <grant type="Spell" id="ID_PHB_SPELL_SHIELD_OF_FAITH" spellcasting="Sorcerer" />
+			<grant type="Spell" id="ID_PHB_SPELL_THUNDEROUS_SMITE" spellcasting="Sorcerer" />
         </rules>
     </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
@@ -27,7 +27,6 @@
 
   <element name="Expanded Spell List" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST">
     <supports>Warlock</supports>
-    <requirements />
     <description>
       <p>The Fates let you choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you.</p>
       <table>
@@ -42,7 +41,7 @@
       </table>
     </description>
     <sheet display="false">
-      <description>The Celestial lets you choose from an expanded list of spells when you learn a warlock spell.</description>
+      <description>The Fates lets you choose from an expanded list of spells when you learn a warlock spell.</description>
     </sheet>
     <spellcasting name="Warlock" extend="true">
       <extend>ID_PHB_SPELL_DETECT_EVIL_AND_GOOD</extend>
@@ -64,7 +63,7 @@
       <p>Starting at 1st level, you are expected to consult with the Fates each morning to learn what they have planned for you. You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain temporary hit points equal to your warlock level (minimum of 1). You must choose a spell that you could normally cast, and you must have the necessary material components.</p>
     </description>
     <sheet>
-      <description>You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain {{level:warlock}} temporary hit points. You must choose a spell that you could normally cast, and you must have the necessary material components.</description>
+      <description>You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain {{level:warlock}} temporary hp. You must choose a spell that you could normally cast, and you must have the necessary material components.</description>
     </sheet>
   </element>
 
@@ -82,7 +81,7 @@
       <p>Starting at 10th level, the weight of your servitude grows heavy, and the burden only lessens when you help another creature meet its fate. Each time you reduce a creature to 0 hit points, you regain one expended spell slot. You may use this feature twice, and you regain any expended uses when you finish a long rest.</p>
     </description>
     <sheet>
-      <description usage="2/Long Rest">When you reduce a creature to 0 hit points, regain one expended spell slot.</description>
+      <description usage="2/Long Rest">When you reduce a creature to 0 hp, regain one expended spell slot.</description>
     </sheet>
   </element>
 
@@ -92,7 +91,7 @@
       <p class="indent">At the beginning of each of the first creature’s turns, if it is not located within 5 feet of the second creature, then the first creature takes 2d10 psychic damage, and it must use its full movement to move closer to the second creature, dashing if necessary, even if it cannot reach them. This effect ends if you or either of the creatures are reduced to 0 hit points or knocked unconscious. Once you use this feature, you can’t use it again until you finish a long rest.</p>
     </description>
     <sheet>
-      <description action="Action">Force a creature you can see to make a Wisdom saving throw. If the creature is unaware of your presence, then it has disadvantage on the roll. If the creature fails the saving throw, choose another creature that you can see. The first creature is compelled by fate to move toward the second creature for 1 minute. At the beginning of each of the first creature’s turns, if it is not located within 5 feet of the second creature, then the first creature takes 2d10 psychic damage, and it must use its full movement to move closer to the second creature, dashing if necessary, even if it cannot reach them. This effect ends if you or either of the creatures are reduced to 0 hit points or knocked unconscious. Once you use this feature, you can’t use it again until you finish a long rest.</description>
+      <description action="Action">Force a creature you can see to make a Wisdom saving throw. If the creature is unaware of your presence, then it has disadvantage on the roll. If the creature fails the saving throw, choose another creature that you can see. The first creature is compelled by fate to move toward the second creature for 1 minute. At the beginning of each of the first creature’s turns, if it is not located within 5 feet of the second creature, then the first creature takes 2d10 psychic damage, and it must use its full movement to move closer to the second creature, dashing if necessary, even if it cannot reach them. This effect ends if you or either of the creatures are reduced to 0 hp or knocked unconscious. Once you use this feature, you can’t use it again until you finish a long rest.</description>
     </sheet>
   </element>
 </elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
@@ -8,7 +8,6 @@
 	</info>
   <element name="The Fates" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_WARLOCK_FATES">
     <supports>Otherworldly Patron</supports>
-    <requirements />
     <description>
       <p>Your otherworldy patron is actually a trio of ancient beings: the coven of hags known as the Fates. The Fates weave the destinies of all gods and mortals in their magical loom, but whether they manipulate fate or merely record it is unknown. You have sworn yourself into the service of the Fates, and they sometimes reward you with glimpses into the future. However, you know that the Fates are utterly evil—whatever power that your pact affords you may pale in comparison to the ugly fate that they have likely prepared for you.</p>
       <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST" />
@@ -26,6 +25,7 @@
       <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_INESCAPABLE_FATE" level="14"/>
     </rules>
   </element>
+
   <element name="Expanded Spell List" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST">
     <supports>Warlock</supports>
     <requirements />
@@ -60,7 +60,7 @@
     <rules></rules>
   </element>
   
-  <element name="Fate's Binding" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_BIDDING">
+  <element name="Fate's Bidding" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_BIDDING">
     <description>
       <p>Starting at 1st level, you are expected to consult with the Fates each morning to learn what they have planned for you. You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain temporary hit points equal to your warlock level (minimum of 1). You must choose a spell that you could normally cast, and you must have the necessary material components.</p>
     </description>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
   <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-warlock-fates.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml" />
 		</update>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+  <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-warlock-fates.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-warlock-fates.xml" />
+		</update>
+	</info>
+  <element name="The Fates" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_WARLOCK_FATES">
+    <supports>Otherworldly Patron</supports>
+    <requirements />
+    <description>
+      <p>Your otherworldy patron is actually a trio of ancient beings: the coven of hags known as the Fates. The Fates weave the destinies of all gods and mortals in their magical loom, but whether they manipulate fate or merely record it is unknown. You have sworn yourself into the service of the Fates, and they sometimes reward you with glimpses into the future. However, you know that the Fates are utterly evil—whatever power that your pact affords you may pale in comparison to the ugly fate that they have likely prepared for you.</p>
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_BIDDING" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_FORETELLING" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_DEMANDS" />
+      <div element="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_INESCAPABLE_FATE" />
+    </description>
+    <sheet display="false" />
+    <rules>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST" level="1"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_BIDDING" level="1"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_FORETELLING" level="6"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_DEMANDS" level="10"/>
+      <grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_INESCAPABLE_FATE" level="14"/>
+    </rules>
+  </element>
+  <element name="Expanded Spell List" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_EXPANDED_SPELL_LIST">
+    <supports>Warlock</supports>
+    <requirements />
+    <description>
+      <p>The Fates let you choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you.</p>
+      <table>
+        <thead>
+          <tr><td>Spell Level</td><td>Spells</td></tr>
+        </thead>
+        <tr><td>1st</td><td><em>detect evil and good, identify</em></td></tr>
+        <tr><td>2nd</td><td><em>levitate, see invisibility</em></td></tr>
+        <tr><td>3rd</td><td><em>clairvoyance, call lightning</em></td></tr>
+        <tr><td>4th</td><td><em>arcane eye, divination</em></td></tr>
+        <tr><td>5th</td><td><em>planar binding, geas</em></td></tr>
+      </table>
+    </description>
+    <sheet display="false">
+      <description>The Celestial lets you choose from an expanded list of spells when you learn a warlock spell.</description>
+    </sheet>
+    <spellcasting name="Warlock" extend="true">
+      <extend>ID_PHB_SPELL_DETECT_EVIL_AND_GOOD</extend>
+      <extend>ID_PHB_SPELL_IDENTIFY</extend>
+      <extend>ID_PHB_SPELL_LEVITATE</extend>
+      <extend>ID_PHB_SPELL_SEE_INVISIBILITY</extend>
+      <extend>ID_PHB_SPELL_CLAIRVOYANCE</extend>
+      <extend>ID_PHB_SPELL_CALL_LIGHTNING</extend>
+      <extend>ID_PHB_SPELL_ARCANE_EYE</extend>
+      <extend>ID_PHB_SPELL_DIVINATION</extend>
+      <extend>ID_PHB_SPELL_PLANAR_BINDING</extend>
+      <extend>ID_PHB_SPELL_GEAS</extend>
+    </spellcasting>
+    <rules></rules>
+  </element>
+  
+  <element name="Fate's Binding" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_BIDDING">
+    <description>
+      <p>Starting at 1st level, you are expected to consult with the Fates each morning to learn what they have planned for you. You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain temporary hit points equal to your warlock level (minimum of 1). You must choose a spell that you could normally cast, and you must have the necessary material components.</p>
+    </description>
+    <sheet>
+      <description>You can cast one divination spell without expending a spell slot immediately after completing a short or long rest. If you do so, you gain {{level:warlock}} temporary hit points. You must choose a spell that you could normally cast, and you must have the necessary material components.</description>
+    </sheet>
+  </element>
+
+  <element name="Fate's Foretelling" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_FORETELLING">
+    <description>
+      <p>Starting at 6th level, you can call on the Fates to foretell future events. When you finish a short or long rest, roll 1d20 and record the number you rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with this roll. You must choose to do so before the roll. This foretelling roll can be used only once. When you finish a short or long rest, you lose any unused foretelling rolls.</p>
+    </description>
+    <sheet>
+      <description>When you finish a short or long rest, roll 1d20 and record the number you rolled. You can replace any attack roll, saving throw, or ability check made by you or a creature that you can see with this roll. You must choose to do so before the roll. This foretelling roll can be used only once. When you finish a short or long rest, you lose any unused foretelling rolls.</description>
+    </sheet>
+  </element>
+
+  <element name="Fate's Demands" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_FATES_DEMANDS">
+    <description>
+      <p>Starting at 10th level, the weight of your servitude grows heavy, and the burden only lessens when you help another creature meet its fate. Each time you reduce a creature to 0 hit points, you regain one expended spell slot. You may use this feature twice, and you regain any expended uses when you finish a long rest.</p>
+    </description>
+    <sheet>
+      <description usage="2/Long Rest">When you reduce a creature to 0 hit points, regain one expended spell slot.</description>
+    </sheet>
+  </element>
+
+  <element name="Inescapable Fate" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_FATES_INESCAPABLE_FATE">
+    <description>
+      <p>Starting at 14th level, you learn to accelerate the entropic power of fate. You can use an action to force a creature you can see to make a Wisdom saving throw. If the creature is unaware of your presence, then it has disadvantage on the roll. If the creature fails the saving throw, choose another creature that you can see. The first creature is compelled by fate to move toward the second creature for 1 minute.</p>
+      <p class="indent">At the beginning of each of the first creature’s turns, if it is not located within 5 feet of the second creature, then the first creature takes 2d10 psychic damage, and it must use its full movement to move closer to the second creature, dashing if necessary, even if it cannot reach them. This effect ends if you or either of the creatures are reduced to 0 hit points or knocked unconscious. Once you use this feature, you can’t use it again until you finish a long rest.</p>
+    </description>
+    <sheet>
+      <description action="Action">Force a creature you can see to make a Wisdom saving throw. If the creature is unaware of your presence, then it has disadvantage on the roll. If the creature fails the saving throw, choose another creature that you can see. The first creature is compelled by fate to move toward the second creature for 1 minute. At the beginning of each of the first creature’s turns, if it is not located within 5 feet of the second creature, then the first creature takes 2d10 psychic damage, and it must use its full movement to move closer to the second creature, dashing if necessary, even if it cannot reach them. This effect ends if you or either of the creatures are reduced to 0 hit points or knocked unconscious. Once you use this feature, you can’t use it again until you finish a long rest.</description>
+    </sheet>
+  </element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+    <info>
+		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
+		<update version="0.0.1">
+			<file name="subclass-wizard-academy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml" />
+		</update>
+	</info>
+	<element name="Academy Philosopher" type="Archetype" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_WIZARD_ACADEMY">
+		<supports>Arcane Tradition</supports>
+		<description>
+			<p>Academy philosophers are great thinkers who do not specialize in any particular spell school, but rather spend their time analyzing the nature of reality and applying that learning to their magic. They usually spend many years studying at venerable schools where philosophers from many different disciplines gather. They enjoy participating in endless debates and dialogues, and they always seek to score points on those who champion rival schools of thought.</p>
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_PHILOSOPHICAL_SCHOOL" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES" />
+			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX" />
+		</description>
+		<sheet>
+			<description>War mages act fast in battle, using their spells to seize tactical control of a situation.</description>
+		</sheet>
+		<rules>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_PHILOSOPHICAL_SCHOOL" level="2"/>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES" level="6"/>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES" level="10"/>
+			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX" level="14"/>
+		</rules>
+	</element>
+
+	<element name="Philosophical School" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_PHILOSOPHICAL_SCHOOL">
+		<description>
+			<p>Starting at 2nd level, you choose from one of several philosophical schools to specialize in at your academy. This school becomes deeply ingrained in your way of thinking about the world.</p>
+		</description>
+		<sheet display="false" />
+		<rules>
+            <select type="Archetype Feature" name="Philosophical School" supports="Philosophical School" />
+        </rules>
+	</element>
+
+    <element name="School: Cynicism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_CYNICISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Cynics believe that one should reject material desires such as wealth and power. They advocate for an ascetic lifestyle, seeking to increase virtue by achieving harmony with nature.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, the gold and time you must spend to copy a spell into your spellbook is halved. Additionally, you may spend 10 minutes foraging to locate the material components for any spell, with a total value of 50 gp or less.</p>
+        </description>
+		<sheet>
+            <description>The gold and time you must spend to copy a spell into your spellbook is halved. Additionally, you may spend 10 minutes foraging to locate the material components for any spell, with a total value of 50 gp or less.</description>
+        </sheet>
+    </element>
+    <element name="School: Eclecticism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_ECLECTICISM" >
+        <supports>Philosophical School</supports>
+        <description>
+            <p>Eclectics believe that no single set of doctrines can be all-encompassing. They adapt the ideas of multiple philosophical schools by choosing what they think is most reasonable.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, you learn an additional language of your choice. Starting at 5th level, choose another philosophical school. You gain the abilities of that school.</p>
+        </description>
+		<sheet display="false" />
+        <rules>
+            <select type="Language" name="Language (Eclecticism)" supports="Standard||Exotic" />
+            <select type="Archetype Feature" name="Philosophical School" supports="School Eclecticism" level="5" />
+        </rules>
+    </element>
+    <element name="School: Empiricism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EMPIRICISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Empiricists believe that the world must be observed to be understood, and that the goal of philosophy is to understand why things are as they are.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, you become proficient in the Perception skill. Additionally, you may cast the <i>identify</i> or <i>detect magic</i> spell once with this trait (without using a spell slot), and you regain the ability to do so after completing a short or long rest.</p>
+        </description>
+		<sheet>
+            <description usage="1/Short Rest">Cast <i>identify</i> or <i>detect magic</i> without using a spell slot.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERCEPTION" />
+            <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" />
+			<grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" />
+        </rules>
+    </element>
+    <element name="School: Epicureanism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EPICUREANISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Epicureans believe that the world is ruled by chance and that appealing to the gods is useless vanity. They believe that happiness is achieved by minimizing pain and living simple lives.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, when a creature you can see attacks you, you can use your reaction to impose disadvantage on the attack roll. You may use this ability a number of times equal to your Intelligence modifier, and it recharges when you complete a short or long rest.</p>
+        </description>
+		<sheet>
+            <description action="Reaction" usage="{{intelligence:modifier}}/Short Rest">When a creature you can see attacks you, impose disadvantage on the attack roll.</description>
+        </sheet>
+    </element>
+    <element name="School: Stoicism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_STOICISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Stoics believe that we must develop self-control and fortitude in order to overcome our own self-destructive emotions. They advocate for humility and faith as antidotes to suffering.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, whenever you take damage that reduces you to 0 hit points or less, you may spend a spell slot of 1st level or higher to be reduced to 1 hit point instead. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
+        </description>
+		<sheet>
+            <description usage="1/Short Rest">Whenever you take damage that reduces you to 0 hit points or less, you may spend a spell slot of 1st level or higher to be reduced to 1 hit point instead.</description>
+        </sheet>
+    </element>
+    <element name="School: Sophism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_SOPHISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Sophists specialize in developing rhetorical and aesthetic powers, and they advocate for principles of excellence and virtue in all endeavors.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, you become proficient in the Persuasion skill and double your proficiency bonus when using that skill. Additionally, you gain the friends cantrip.</p>
+        </description>
+		<sheet>
+            <description>Double your proficiency bonus when making a Persuasion check.</description>
+        </sheet>
+        <rules>
+            <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERSUASION" />
+        </rules>
+    </element>
+    <element name="School: Hedonism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_HEDONISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Hedonists believe that pleasure is the supreme good, and that everyone should seek to achieve the immediate gratification of their desires.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, when you regain hit points from a spell or ability, you may choose to add twice your wizard level to the number of hit points restored. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
+        </description>
+		<sheet>
+            <description usage="1/Short Rest">When you regain hit points from a spell or ability, you may choose to add {{hedonism:hp}} to the number of hit points restored.</description>
+        </sheet>
+        <rules>
+            <stat name="hedonism:hp" value="level:wizard" />
+            <stat name="hedonism:hp" value="level:wizard" />
+        </rules>
+    </element>
+    <element name="School: Empiricism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EMPIRICISM" >
+        <supports>Philosophical School, School Eclecticism</supports>
+        <description>
+            <p>Skeptics believe that to truly possess knowledge of things is impossible. They believe that there are universal truths, but they cannot be understood well enough to shape dogmatic ideas about the world.</p>
+            <p class="indent">Starting when you choose this school at 2nd level, you have advantage on ability checks to detect visual illusions and on saving throws against effects imposed by them. You also have advantage on saving throws against spells and effects that would charm you.</p>
+        </description>
+		<sheet>
+            <description>You have advantage on ability checks to detect visual illusions and on saving throws against effects imposed by them. You also have advantage on saving throws against spells and effects that would charm you.</description>
+        </sheet>
+    </element>
+
+	<element name="Mathematical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES">
+		<description>
+			<p>Starting at 6th level, you have spent years solving complex mathematical equations, allowing you to shape your spells with precision and create pockets of safety for allies. When you cast a spell that affects other creatures that you can see, you may choose a number of them equal to your Intelligence modifier. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</p>
+		</description>
+		<sheet>
+			<description>When you cast a spell that affects other creatures that you can see, you may choose {{intelligence:modifier}} of them. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</description>
+		</sheet>
+	</element>
+
+	<element name="Metaphysical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES">
+		<description>
+			<p>Starting at 10th level, you gain new insights into the nature of causality. Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
+		</description>
+		<sheet>
+			<description usage="1/Short Rest">Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell.</description>
+		</sheet>
+		<rules />
+	</element>
+
+	<element name="Magical Paradox" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX">
+		<description>
+			<p>Starting at 14th level, you’ve spent years studying philosophical paradoxes, which allows you to work seemingly impossible feats with magic. Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated. You may use this feature a number of times equal to your Intelligence modifier, and you regain any expended uses after a long rest.</p>
+		</description>
+		<sheet>
+			<description usage="{{intelligence:modifier}}/Long Rest">Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated.</description>
+		</sheet>
+	</element>
+</elements>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
@@ -24,17 +24,14 @@
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX" level="14"/>
 		</rules>
 	</element>
-
 	<element name="Philosophical School" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_PHILOSOPHICAL_SCHOOL">
 		<description>
 			<p>Starting at 2nd level, you choose from one of several philosophical schools to specialize in at your academy. This school becomes deeply ingrained in your way of thinking about the world.</p>
 		</description>
-		<sheet display="false" />
 		<rules>
-            <select type="Archetype Feature" name="Philosophical School" supports="Philosophical School" />
+            <select type="Archetype Feature" name="Philosophical School" supports="Philosophical School Specialization" />
         </rules>
 	</element>
-
 	<element name="Mathematical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES">
 		<description>
 			<p>Starting at 6th level, you have spent years solving complex mathematical equations, allowing you to shape your spells with precision and create pockets of safety for allies. When you cast a spell that affects other creatures that you can see, you may choose a number of them equal to your Intelligence modifier. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</p>
@@ -43,7 +40,6 @@
 			<description>When you cast a spell that affects other creatures that you can see, you may choose {{intelligence:modifier}} of them. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</description>
 		</sheet>
 	</element>
-
 	<element name="Metaphysical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES">
 		<description>
 			<p>Starting at 10th level, you gain new insights into the nature of causality. Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
@@ -53,7 +49,6 @@
 		</sheet>
 		<rules />
 	</element>
-
 	<element name="Magical Paradox" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX">
 		<description>
 			<p>Starting at 14th level, you’ve spent years studying philosophical paradoxes, which allows you to work seemingly impossible feats with magic. Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated. You may use this feature a number of times equal to your Intelligence modifier, and you regain any expended uses after a long rest.</p>
@@ -65,96 +60,96 @@
 
     <!-- Philosophical School options -->
     <element name="School: Cynicism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_CYNICISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Cynics believe that one should reject material desires such as wealth and power. They advocate for an ascetic lifestyle, seeking to increase virtue by achieving harmony with nature.</p>
             <p class="indent">Starting when you choose this school at 2nd level, the gold and time you must spend to copy a spell into your spellbook is halved. Additionally, you may spend 10 minutes foraging to locate the material components for any spell, with a total value of 50 gp or less.</p>
         </description>
-		<sheet>
+		<sheet alt="Cynicism">
             <description>The gold and time you must spend to copy a spell into your spellbook is halved. Additionally, you may spend 10 minutes foraging to locate the material components for any spell, with a total value of 50 gp or less.</description>
         </sheet>
     </element>
     <element name="School: Eclecticism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_ECLECTICISM" >
-        <supports>Philosophical School</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Eclectics believe that no single set of doctrines can be all-encompassing. They adapt the ideas of multiple philosophical schools by choosing what they think is most reasonable.</p>
             <p class="indent">Starting when you choose this school at 2nd level, you learn an additional language of your choice. Starting at 5th level, choose another philosophical school. You gain the abilities of that school.</p>
         </description>
-		<sheet display="false" />
+		<sheet alt="Eclecticism" />
         <rules>
             <select type="Language" name="Language (Eclecticism)" supports="Standard||Exotic" />
-            <select type="Archetype Feature" name="Philosophical School" supports="School Eclecticism" level="5" />
+            <select type="Archetype Feature" name="Eclecticism, Philosophical School" supports="Philosophical School Specialization" level="5" />
         </rules>
     </element>
     <element name="School: Empiricism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EMPIRICISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Empiricists believe that the world must be observed to be understood, and that the goal of philosophy is to understand why things are as they are.</p>
             <p class="indent">Starting when you choose this school at 2nd level, you become proficient in the Perception skill. Additionally, you may cast the <i>identify</i> or <i>detect magic</i> spell once with this trait (without using a spell slot), and you regain the ability to do so after completing a short or long rest.</p>
         </description>
-		<sheet>
-            <description usage="1/Short Rest">Cast <i>identify</i> or <i>detect magic</i> without using a spell slot.</description>
+		<sheet alt="Empiricism">
+            <description usage="1/Short Rest">You can cast identify or detect magic without using a spell slot.</description>
         </sheet>
         <rules>
             <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERCEPTION" />
-            <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" />
-			<grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" />
+            <grant type="Spell" id="ID_PHB_SPELL_IDENTIFY" spellcasting="Wizard" />
+			<grant type="Spell" id="ID_PHB_SPELL_DETECT_MAGIC" spellcasting="Wizard" />
         </rules>
     </element>
     <element name="School: Epicureanism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EPICUREANISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Epicureans believe that the world is ruled by chance and that appealing to the gods is useless vanity. They believe that happiness is achieved by minimizing pain and living simple lives.</p>
             <p class="indent">Starting when you choose this school at 2nd level, when a creature you can see attacks you, you can use your reaction to impose disadvantage on the attack roll. You may use this ability a number of times equal to your Intelligence modifier, and it recharges when you complete a short or long rest.</p>
         </description>
-		<sheet>
+		<sheet alt="Epicureanism">
             <description action="Reaction" usage="{{intelligence:modifier}}/Short Rest">When a creature you can see attacks you, impose disadvantage on the attack roll.</description>
         </sheet>
     </element>
     <element name="School: Stoicism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_STOICISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Stoics believe that we must develop self-control and fortitude in order to overcome our own self-destructive emotions. They advocate for humility and faith as antidotes to suffering.</p>
             <p class="indent">Starting when you choose this school at 2nd level, whenever you take damage that reduces you to 0 hit points or less, you may spend a spell slot of 1st level or higher to be reduced to 1 hit point instead. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
         </description>
-		<sheet>
-            <description usage="1/Short Rest">Whenever you take damage that reduces you to 0 hit points or less, you may spend a spell slot of 1st level or higher to be reduced to 1 hit point instead.</description>
+		<sheet alt="Stoicism">
+            <description usage="1/Short Rest">Whenever you take damage that reduces you to 0 hp or less, you may spend a spell slot of 1st level or higher to be reduced to 1 hp instead.</description>
         </sheet>
     </element>
     <element name="School: Sophism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_SOPHISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Sophists specialize in developing rhetorical and aesthetic powers, and they advocate for principles of excellence and virtue in all endeavors.</p>
             <p class="indent">Starting when you choose this school at 2nd level, you become proficient in the Persuasion skill and double your proficiency bonus when using that skill. Additionally, you gain the friends cantrip.</p>
         </description>
-		<sheet>
-            <description>Double your proficiency bonus when making a Persuasion check.</description>
-        </sheet>
+		<sheet alt="Sophism" />
         <rules>
             <grant type="Proficiency" id="ID_PROFICIENCY_SKILL_PERSUASION" />
+            <stat name="persuasion:proficiency" value="proficiency" bonus="double" />
+            <grant type="Spell" id="ID_PHB_SPELL_FRIENDS" spellcasting="Wizard" />
         </rules>
     </element>
     <element name="School: Hedonism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_HEDONISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Hedonists believe that pleasure is the supreme good, and that everyone should seek to achieve the immediate gratification of their desires.</p>
             <p class="indent">Starting when you choose this school at 2nd level, when you regain hit points from a spell or ability, you may choose to add twice your wizard level to the number of hit points restored. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
         </description>
-		<sheet>
-            <description usage="1/Short Rest">When you regain hit points from a spell or ability, you may choose to add {{hedonism:hp}} to the number of hit points restored.</description>
+		<sheet alt="Hedonism">
+            <description usage="1/Short Rest">When you regain hp from a spell or ability, you may choose to add {{hedonism:hp}} to the number of hp restored.</description>
         </sheet>
         <rules>
             <stat name="hedonism:hp" value="level:wizard" />
             <stat name="hedonism:hp" value="level:wizard" />
         </rules>
     </element>
-    <element name="School: Empiricism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_EMPIRICISM" >
-        <supports>Philosophical School, School Eclecticism</supports>
+    <element name="School: Skepticism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_SKEPTICISM" >
+        <supports>Philosophical School Specialization</supports>
         <description>
             <p>Skeptics believe that to truly possess knowledge of things is impossible. They believe that there are universal truths, but they cannot be understood well enough to shape dogmatic ideas about the world.</p>
             <p class="indent">Starting when you choose this school at 2nd level, you have advantage on ability checks to detect visual illusions and on saving throws against effects imposed by them. You also have advantage on saving throws against spells and effects that would charm you.</p>
         </description>
-		<sheet>
+		<sheet alt="Skepticism">
             <description>You have advantage on ability checks to detect visual illusions and on saving throws against effects imposed by them. You also have advantage on saving throws against spells and effects that would charm you.</description>
         </sheet>
     </element>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <elements>
     <info>
-		<author url="https://www.arcanumworlds.com/">Arcanum Worlds</author>
 		<update version="0.0.1">
 			<file name="subclass-wizard-academy.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml" />
 		</update>
@@ -15,8 +14,8 @@
 			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES" />
 			<div element="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX" />
 		</description>
-		<sheet>
-			<description>War mages act fast in battle, using their spells to seize tactical control of a situation.</description>
+		<sheet display="false">
+			<description>Academy philosophers are great thinkers who do not specialize in any particular spell school, but rather spend their time analyzing the nature of reality and applying that learning to their magic.</description>
 		</sheet>
 		<rules>
 			<grant type="Archetype Feature" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_PHILOSOPHICAL_SCHOOL" level="2"/>

--- a/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
+++ b/third-party/arcanum-worlds/odyssey-of-the-dragonlords/subclass-wizard-academy.xml
@@ -36,6 +36,35 @@
         </rules>
 	</element>
 
+	<element name="Mathematical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES">
+		<description>
+			<p>Starting at 6th level, you have spent years solving complex mathematical equations, allowing you to shape your spells with precision and create pockets of safety for allies. When you cast a spell that affects other creatures that you can see, you may choose a number of them equal to your Intelligence modifier. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</p>
+		</description>
+		<sheet>
+			<description>When you cast a spell that affects other creatures that you can see, you may choose {{intelligence:modifier}} of them. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</description>
+		</sheet>
+	</element>
+
+	<element name="Metaphysical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES">
+		<description>
+			<p>Starting at 10th level, you gain new insights into the nature of causality. Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
+		</description>
+		<sheet>
+			<description usage="1/Short Rest">Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell.</description>
+		</sheet>
+		<rules />
+	</element>
+
+	<element name="Magical Paradox" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX">
+		<description>
+			<p>Starting at 14th level, you’ve spent years studying philosophical paradoxes, which allows you to work seemingly impossible feats with magic. Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated. You may use this feature a number of times equal to your Intelligence modifier, and you regain any expended uses after a long rest.</p>
+		</description>
+		<sheet>
+			<description usage="{{intelligence:modifier}}/Long Rest">Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated.</description>
+		</sheet>
+	</element>
+
+    <!-- Philosophical School options -->
     <element name="School: Cynicism" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_CYNICISM" >
         <supports>Philosophical School, School Eclecticism</supports>
         <description>
@@ -130,32 +159,4 @@
             <description>You have advantage on ability checks to detect visual illusions and on saving throws against effects imposed by them. You also have advantage on saving throws against spells and effects that would charm you.</description>
         </sheet>
     </element>
-
-	<element name="Mathematical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MATHEMATICAL_PRINCIPLES">
-		<description>
-			<p>Starting at 6th level, you have spent years solving complex mathematical equations, allowing you to shape your spells with precision and create pockets of safety for allies. When you cast a spell that affects other creatures that you can see, you may choose a number of them equal to your Intelligence modifier. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</p>
-		</description>
-		<sheet>
-			<description>When you cast a spell that affects other creatures that you can see, you may choose {{intelligence:modifier}} of them. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save. Additionally, when you cast a spell that has an area of effect radius, you may choose to increase or decrease the radius by 5 feet.</description>
-		</sheet>
-	</element>
-
-	<element name="Metaphysical Principles" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_METAPHYSICAL_PRINCIPLES">
-		<description>
-			<p>Starting at 10th level, you gain new insights into the nature of causality. Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell. Once you have used this feature, you may not use it again until you complete a short or long rest.</p>
-		</description>
-		<sheet>
-			<description usage="1/Short Rest">Whenever a creature casts a spell with a single target that you can see, you can use your reaction to choose a new target for the spell. The new target must be legal for that spell.</description>
-		</sheet>
-		<rules />
-	</element>
-
-	<element name="Magical Paradox" type="Archetype Feature" source="Odyssey of the Dragonlords" id="ID_AW_OOTD_ARCHETYPE_FEATURE_ACADEMY_MAGICAL_PARADOX">
-		<description>
-			<p>Starting at 14th level, you’ve spent years studying philosophical paradoxes, which allows you to work seemingly impossible feats with magic. Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated. You may use this feature a number of times equal to your Intelligence modifier, and you regain any expended uses after a long rest.</p>
-		</description>
-		<sheet>
-			<description usage="{{intelligence:modifier}}/Long Rest">Whenever you would lose concentration on a spell for any reason, you may choose to maintain concentration instead, as long as you are not incapacitated.</description>
-		</sheet>
-	</element>
 </elements>


### PR DESCRIPTION
Content from Odyssey of the Dragonlords, Arcanum Worlds (request #431 )

Changed existing files:
- third-party.index

New files:
- arcanum-worlds.index
- odyssey-of-the-dragonlords.index
- source.xml

- aw-ootd-spells.xml
- aw-ootd-weapons.xml
- race-thyleancentaur.xml
- race-thyleanmedusa.xml
- race-thyleanminotaur.xml
- race-thyleannymph.xml
- race-thyleansatyr.xml
- race-thyleansiren.xml
- subclass-barbarian-herculean.xml
- subclass-bard-epicpoetry.xml
- subclass-cleric-prophecy.xml
- subclass-druid-sacrifice.xml
- subclass-fighter-hoplite.xml
- subclass-monk-shield.xml
- subclass-paladin-dragonlord.xml
- subclass-ranger-amazonian.xml
- subclass-rogue-odyssean.xml
- subclass-sorcerer-demigod.xml
- subclass-warlock-fates.xml
- subclass-wizard-academy.xml