### PR TITLE
[PHB] Rogues' Tool Expertise

### DIFF
--- a/core/players-handbook/classes/class-rogue.xml
+++ b/core/players-handbook/classes/class-rogue.xml
@@ -4,7 +4,7 @@
 		<name>Rogue</name>
 		<description>The Rogue class from the Player’s Handbook.</description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.2.8">
+		<update version="0.2.9">
 			<file name="class-rogue.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/classes/class-rogue.xml" />
 		</update>
 	</info>
@@ -816,7 +816,9 @@
 				<div element="ID_WOTC_PHB_ITEM_TOOL_THIEVES_TOOLS" />
 			</div>
 		</description>
-		<sheet display="false" />
+		<sheet>
+        	<description>Your proficiency bonus is doubled for any Thieves’ Tools check you make.</description>
+		</sheet>
 		<rules>
 			<stat name="thieves tools:proficiency" value="proficiency" bonus="double" />
 		</rules>


### PR DESCRIPTION
Requested on [reddit](https://www.reddit.com/r/aurorabuilder/comments/eotllp/tool_proficiency_expertise_doesnt_show_up_on/)
• Tool Expertise is now displayed on the sheet in **Features & Traits** box.