### PR TITLE
Corrected the oath of conquest description

### DIFF
--- a/supplements/xanathars-guide-to-everything/archetypes/paladin-conquest.xml
+++ b/supplements/xanathars-guide-to-everything/archetypes/paladin-conquest.xml
@@ -4,7 +4,7 @@
     <name>Oath of Conquest</name>
     <description>The Oath of Conquest from Xanathar’s Guide to Everything</description>
     <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything">Xanathar’s Guide to Everything</author>
-    <update version="0.0.3">
+    <update version="0.0.4">
       <file name="paladin-conquest.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/supplements/xanathars-guide-to-everything/archetypes/paladin-conquest.xml" />
     </update>
   </info>
@@ -26,7 +26,7 @@
       <div element="ID_WOTC_XGTE_ARCHETYPE_FEATURE_OATH_OF_CONQUEST_INVINCIBLE_CONQUEROR" />
     </description>
     <sheet>
-      <description>The Oath of Conquest sets a paladin on a difficult path, one that requires a holy warrior to use violence only as a last resort.</description>
+      <description>The Oath of Conquest calls to paladins who seek glory in battle and the subjugation of their enemies.</description>
     </sheet>
     <rules>
       <grant type="Archetype Feature" id="ID_WOTC_XGTE_ARCHETYPE_FEATURE_OATH_OF_CONQUEST_OATH_SPELLS" level="1" />


### PR DESCRIPTION
Fixed the oath of conquest description printed on the pdf from:
The Oath of Conquest sets a paladin on a difficult path, one that requires a holy warrior to use violence only as a last resort.
To
The Oath of Conquest calls to paladins who seek glory in battle and the subjugation of their enemies.