### PR TITLE
UA20200326 Spells and Magic Tattoos

### DIFF
--- a/unearthed-arcana.index
+++ b/unearthed-arcana.index
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana</name>
 		<description>The material presented in Unearthed Arcana will range from mechanics that we expect one day to publish in a supplement to house rules from our home campaigns that we want to share, from core system options to setting-specific material. Once it’s out there, you can expect us to check in with you to see how it’s working out and what we can do to improve it.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana">Wizards of the Coast</author>
-		<update version="0.6">
+		<update version="0.6.1">
 			<file name="unearthed-arcana.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana.index" />
 		</update>
 	</info>
@@ -95,6 +95,7 @@
 		<!-- todo: obsolete 20200204 in favor for 20200206 -->
 		<!-- <file name="20200206.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200206.xml" /> -->
 		<file name="20200224.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200224.xml" />
+		<file name="20200326.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200326.xml" />
 
 	</files>
 </index>

--- a/unearthed-arcana/2020/20200326.xml
+++ b/unearthed-arcana/2020/20200326.xml
@@ -98,6 +98,9 @@
 			<p>You call forth a spirit from the Far Realm or another alien realm of madness. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Aberrant Spirit stat block below. When you cast the spell, choose Beholderkin, Slaadi, or Star Spawn. The creature physically resembles your choice, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_ABERRANT_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -120,6 +123,9 @@
 			<p>You call forth the spirit of a beast. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Bestial Spirit stat block below. When you cast the spell, choose an environment: Air, Land, or Water. The creature physically resembles an animal of your choice that is native to the chosen environment, which also determines one of the movement modes in the creature’s stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 3rd level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_BESTIAL_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -142,6 +148,9 @@
 			<p>You call forth a spirit from the Upper Planes. The spirit manifests physically in an angelic form in an unoccupied space that you can see within range. This corporeal form uses the Celestial Spirit stat block below. When you cast the spell, choose Avenger or Defender. Your choice determines the creature’s attack in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 6th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_CELESTIAL_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -164,6 +173,9 @@
 			<p>You call forth a spirit from the Elemental Planes. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Elemental Spirit stat block below. When you cast the spell, choose an element: Air, Earth, Fire, or Water. The creature physically resembles a vaguely humanoid form wreathed in the chosen element, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_ELEMENTAL_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -186,6 +198,9 @@
 			<p>You call forth a spirit from the Feywild. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Fey Spirit stat block below. When you cast the spell, choose a mood: Deceitful, Furious, or Joyful. The creature physically resembles a satyr, a dryad, or an elf (your choice) marked by the chosen mood, which also determines one of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_FEY_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -208,6 +223,9 @@
 			<p>You call forth a fiendish spirit from the Lower Planes. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Fiendish Spirit stat block below. When you cast the spell, choose Demon, Devil, or Yugoloth. The creature physically resembles a fiend of the chosen type, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 7th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_FIENDISH_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -230,6 +248,9 @@
 			<p>You call forth a shadowy spirit from the Shadowfell. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Shadow Spirit stat block below. When you cast the spell, choose an emotion: Fury, Despair, or Fear. The creature physically resembles a misshapen humanoid marked by the chosen emotion, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_SHADOW_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -252,6 +273,9 @@
 			<p>You call forth a restless spirit from beyond the grave. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Undead Spirit stat block below. When you cast the spell, choose the creature’s form: Ghostly, Putrid, or Skeletal. The creature physically resembles a humanoid with the chosen form, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
 			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
 			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200326_INFORMATION_SUMMON_UNDEAD_SPIRIT_STATBLOCK" />
+			</div>
 		</description>
 		<setters>
 			<set name="keywords"></set>
@@ -715,6 +739,231 @@
 			<set name="rarity">Very Rare</set>
 			<set name="attunement">true</set>
 		</setters>
+	</element>	
+
+	<element name="Aberrant Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_ABERRANT_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Medium aberration, neutral evil</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the aberration’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 30 ft., fly 30 ft. (Beholderkin only; hover)</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>16 (+3)</td><td>10 (+0)</td><td>15 (+2)</td><td>16 (+3)</td><td>10 (+0)</td><td>6 (-2)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Immunities</strong> psychic</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Deep Speech, understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Regeneration (Slaadi Only).</em></strong> The aberration regains 10 hit points at the start of its turn if it has at least 1 hit point.</p>
+			<p><strong><em>Whispering Aura (Star Spawn Only).</em></strong> At the start of each of the aberration’s turns, each creature within 5 feet of it must succeed on a Wisdom saving throw against your spell save DC or take 3d6 psychic damage, provided that the aberration isn’t incapacitated.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The aberration makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Eye Ray (Beholderkin Only).</em></strong> Ranged Spell Attack: +3 + the spell’s level to hit, range 30 ft., one creature. Hit: 1d8 + 3 + the spell’s level psychic damage.</p>
+			<p><strong><em>Claws (Slaadi Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d10 + 3 + the spell’s level slashing damage. If the target is a creature, it can’t regain hit points until the start of the aberration’s next turn.</p>
+			<p><strong><em>Psychic Slam (Star Spawn Only).</em></strong> Melee Spell Attack: +3 + the spell’s level to hit, reach 5 ft., one creature. Hit: 1d6 + 3 + the spell’s level psychic damage.</p>
+		</description>
 	</element>
-	
+	<element name="Bestial Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_BESTIAL_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Small beast, unaligned</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the beast’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 30 ft., climb 30 ft. (Land only), fly 60 ft. (Air only), swim 30 ft. (Water only)</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>18 (+4)</td><td>11 (+0)</td><td>16 (+3)</td><td>4 (-4)</td><td>14 (+2)</td><td>5 (-3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 12</li>
+				<li><strong>Languages</strong> understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Amphibious (Water Only).</em></strong> The beast can breathe air and water.</p>
+			<p><strong><em>Flyby (Air Only).</em></strong> The beast doesn’t provoke opportunity attacks when it flies out of an enemy’s reach.</p>
+			<p><strong><em>Pack Tactics (Land and Water Only).</em></strong> The beast has advantage on an attack roll against a creature if at least one of the beast’s allies is within 5 feet of the creature and the ally isn’t incapacitated.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The beast makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Maul.</em></strong> Melee Weapon Attack: +4 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d8 + 4 + the spell’s level piercing damage.</p>
+		</description>
+	</element>
+	<element name="Celestial Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_CELESTIAL_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Large celestial, neutral good</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the celestial’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 30 ft., fly 40 ft.</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>16 (+3)</td><td>14 (+2)</td><td>16 (+3)</td><td>10 (+0)</td><td>14 (+2)</td><td>16 (+3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Resistances</strong> radiant</li>
+				<li><strong>Condition Immunities</strong> charmed, frightened</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Celestial, understands the languages you speak</li>
+			</ul>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The celestial makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Radiant Bow (Avenger Only).</em></strong> Ranged Weapon Attack: +2 + the spell’s level to hit, range 150/600 ft., one target. Hit: 2d6 + 2 + the spell’s level radiant damage.</p>
+			<p><strong><em>Radiant Mace (Defender Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d10 + 3 + the spell’s level radiant damage, and the celestial can choose itself or another creature it can see within 10 feet of the target. The chosen creature gains temporary hit points equal to the damage dealt, provided it doesn’t already have temporary hit points.</p>
+			<p><strong><em>Healing Touch (1/Day).</em></strong> The celestial touches another creature. The target magically regains hit points equal to 2d8 + the spell’s level.</p>
+		</description>
+	</element>
+	<element name="Elemental Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_ELEMENTAL_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Medium elemental, neutral</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the elemental’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 40 ft., fly 40 ft. (Air only, hover), burrow 40 ft. (Earth only), swim 40 ft. (Water only)</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>18 (+4)</td><td>15 (+2)</td><td>17 (+3)</td><td>4 (-4)</td><td>10 (+0)</td><td>16 (+3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Resistances</strong> lightning, thunder (Air only); piercing, slashing (Earth only); acid (Water only)</li>
+				<li><strong>Damage Immunities</strong> poison; fire (Fire only)</li>
+				<li><strong>Condition Immunities</strong> exhaustion, paralyzed, petrified, poisoned, unconscious</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Primordial, understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Amorphous Form (Air, Fire, and Water Only).</em></strong> The elemental can move through a space as narrow as 1 inch wide without squeezing.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The elemental makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Slam.</em></strong> Melee Weapon Attack: +4 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d10 + 4 + the spell’s level bludgeoning damage (Air, Earth, and Water only) or fire damage (Fire only).</p>
+		</description>
+	</element>
+	<element name="Fey Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_FEY_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Small fey, chaotic good</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the fey’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 40 ft.</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>13 (+1)</td><td>16 (+3)</td><td>14 (+2)</td><td>14 (+2)</td><td>11 (+0)</td><td>16 (+3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Condition Immunities</strong> charmed</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Sylvan, understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Fey Step.</em></strong> As a bonus action, the fey can magically teleport up to 30 feet to an unoccupied space it can see.</p>
+			<p><strong><em>Darkening Step (Deceitful Only).</em></strong> Immediately after using its Fey Step, the fey can fill a 5-foot cube within 5 feet of it with magical darkness, which remains until the end of the fey’s next turn.</p>
+			<p><strong><em>Ecstatic Step (Joyful Only).</em></strong> Immediately after using its Fey Step, the fey can choose a creature it can see within 10 feet of it and force it to succeed on a Wisdom saving throw against your spell save DC or be charmed by the fey for 1 minute. The charm ends if the fey or any of its companions deals any damage to the target.</p>
+			<p><strong><em>Impassioned Step (Furious Only).</em></strong> Immediately after using its Fey Step, the fey has advantage on the next attack roll it makes before the end of its turn.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The fey makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Shortsword.</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d6 + 3 + the spell’s level piercing damage + 1d6 force damage.</p>
+		</description>
+	</element>
+	<element name="Fiendish Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_FIENDISH_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Large fiend, chaotic evil (Demon only), lawful evil (Devil only), or neutral evil (Yugoloth only)</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the fiend’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 40 ft., climb 40 ft. (Demon only), fly 60 ft. (Devil only)</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>13 (+1)</td><td>16 (+3)</td><td>15 (+2)</td><td>10 (+0)</td><td>10 (+0)</td><td>16 (+3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Resistances</strong> fire</li>
+				<li><strong>Damage Immunities</strong> poison</li>
+				<li><strong>Condition Immunities</strong> poisoned</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Abyssal, Infernal, telepathy 60 ft.</li>
+			</ul>
+			<p><strong><em>Magic Resistance.</em></strong> The fiend has advantage on saving throws against spells and other magical effects.</p>
+			<p><strong><em>Death Throes (Demon Only).</em></strong> When the fiend drops to 0 hit points or the spell ends, the fiend explodes, and each creature within 10 feet of it must make a Dexterity saving throw against your spell save DC. A creature takes 2d10 + this spell’s level fire damage on a failed save, or half as much damage on a successful one.</p>
+			<p><strong><em>Devil’s Sight (Devil Only).</em></strong> Magical darkness doesn’t impede the fiend’s darkvision.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The fiend makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Bite (Demon Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d12 + 3 + the spell’s level necrotic damage.</p>
+			<p><strong><em>Claws (Yugoloth Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d8 + 3 + the spell’s level slashing damage. Immediately after the attack hits or misses, the fiend can magically teleport up to 30 feet to an unoccupied space it can see.</p>
+			<p><strong><em>Hurl Flame (Devil Only).</em></strong> Ranged Spell Attack: +3 + the spell’s level to hit, range 150 ft., one target. Hit: 2d6 + 3 + the spell’s level fire damage. If the target is a flammable object that isn’t being worn or carried, it also catches fire.</p>
+		</description>
+	</element>
+	<element name="Shadow Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_SHADOW_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Medium monstrosity, neutral evil</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the shadow’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 40 ft.</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>13 (+1)</td><td>16 (+3)</td><td>15 (+2)</td><td>4 (-4)</td><td>10 (+0)</td><td>16 (+3)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Resistances</strong> necrotic</li>
+				<li><strong>Condition Immunities</strong> frightened</li>
+				<li><strong>Senses</strong> darkvision 120 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Common, understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Bloodthirsty Frenzy (Fury Only).</em></strong> The spirit has advantage on attack rolls against frightened creatures.</p>
+			<p><strong><em>Shadow Stealth (Fear Only).</em></strong> While in dim light or darkness, the spirit can take the Hide action as a bonus action.</p>
+			<p><strong><em>Weight of Ages (Despair Only).</em></strong> Any beast or humanoid, other than you, that starts its turn within 5 feet of the spirit has its speed reduced by 20 feet until the start of that beast or humanoid’s next turn.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The spirit makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Chilling Rend.</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 2d8 + 3 + the spell’s level cold damage.</p>
+			<p><strong><em>Dreadful Scream (1/Day).</em></strong> The spirit screams. Each creature within 30 feet of it must succeed on a Wisdom saving throw against your spell save DC or be frightened of the spirit for 1 minute. The frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.</p>
+		</description>
+	</element>
+	<element name="Undead Spirit" type="Information" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_INFORMATION_SUMMON_UNDEAD_SPIRIT_STATBLOCK">
+		<description>
+			<p><em>Medium undead, neutral evil</em></p>
+			<ul class="unstyled mb">
+				<li><strong>Armor Class</strong> 11 + the level of the spell (natural armor)</li>
+				<li><strong>Hit Points</strong> equal the undead’s Constitution modifier + your spellcasting ability modifier + ten times the spell’s level</li>
+				<li><strong>Speed</strong> 30 ft., fly 40 ft. (Ghostly only; hover)</li>
+			</ul>
+			<table style="text-align:center">
+				<thead>
+					<tr><td>STR</td><td>DEX</td><td>CON</td><td>INT</td><td>WIS</td><td>CHA</td></tr>
+				</thead>
+				<tr><td>12 (+1)</td><td>16 (+3)</td><td>15 (+2)</td><td>4 (-4)</td><td>10 (+0)</td><td>9 (-1)</td></tr>
+			</table>
+			<ul class="unstyled mb">
+				<li><strong>Damage Immunities</strong> necrotic, poison</li>
+				<li><strong>Condition Immunities</strong> exhaustion, frightened, paralyzed, poisoned</li>
+				<li><strong>Senses</strong> darkvision 60 ft., passive Perception 10</li>
+				<li><strong>Languages</strong> Common, understands the languages you speak</li>
+			</ul>
+			<p><strong><em>Incorporeal Movement (Ghostly Only).</em></strong> The undead can become incorporeal while moving and pass through other creatures and objects as if they were difficult terrain. If it ends its turn inside an object, it is shunted to the nearest unoccupied space and takes 1d10 force damage for every 5 feet traveled.</p>
+			<p><strong><em>Festering Aura (Putrid Only).</em></strong> Any creature, other than you, that starts its turn within 5 feet of the undead must succeed on a Constitution saving throw against your spell save DC or be poisoned until the start of its next turn.</p>
+			<h5 class="caption">ACTIONS</h5>
+			<p><strong><em>Multiattack.</em></strong> The spirit makes a number of attacks equal to half this spell’s level (rounded down).</p>
+			<p><strong><em>Deathly Touch (Ghostly Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one creature. Hit: 1d8 + 3 + the spell’s level necrotic damage, and the creature must succeed on a Wisdom saving throw against your spell save DC or be frightened of the undead until the end of the target’s next turn.</p>
+			<p><strong><em>Grave Bolt (Skeletal Only).</em></strong> Ranged Spell Attack: +3 + the spell’s level to hit, range 150 ft., one target. Hit: 2d8 + 3 + the spell’s level necrotic damage.</p>
+			<p><strong><em>Rotting Claw (Putrid Only).</em></strong> Melee Weapon Attack: +3 + the spell’s level to hit, reach 5 ft., one target. Hit: 1d6 + 3 + the spell’s level slashing damage. If the target is poisoned, it must succeed on a Constitution saving throw against your spell save DC or be paralyzed until the end of its next turn.</p>
+		</description>
+	</element>
 </elements>

--- a/unearthed-arcana/2020/20200326.xml
+++ b/unearthed-arcana/2020/20200326.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<name>Unearthed Arcana: Spells and Magic Tattoos</name>
+		<update version="0.0.1">
+			<file name="20200326.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200326.xml" />
+		</update>
+	</info>	
+	<element name="Unearthed Arcana: Spells and Magic Tattoos" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20200326">
+		<description>
+			<p>Conjure forth new magic in your D&amp;D games with the spells and tattoos introduced in today’s Unearthed Arcana. Many of the spells focus on summoning, and the tattoos allow you to ink magic onto your very skin.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20200326</set>
+			<set name="url">https://dnd.wizards.com/articles/unearthed-arcana/spells-magic-tattoos</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20200326</set>
+		</setters>
+	</element>
+
+
+	
+	
+</elements>

--- a/unearthed-arcana/2020/20200326.xml
+++ b/unearthed-arcana/2020/20200326.xml
@@ -268,59 +268,243 @@
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
-	
-	<element name="Absorbing Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO">
+
+	<element name="Absorbing Tattoo, Acid" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_ACID">
 		<description>
-			<p>This tattoo incorporates designs that emphasize one color more than others. While the tattoo is on your skin, you have resistance to a type of damage associated with that color, as shown on the table below. The DM chooses the color or determines it randomly.</p>
-			<table>
-				<thead>
-					<tr><td>d10</td><td>Damage Type</td><td>Color</td></tr>
-				</thead>
-				<tr><td>1</td><td>Acid</td><td>Green</td></tr>
-				<tr><td>2</td><td>Cold</td><td>Blue</td></tr>
-				<tr><td>3</td><td>Fire</td><td>Red</td></tr>
-				<tr><td>4</td><td>Force</td><td>White</td></tr>
-				<tr><td>5</td><td>Lightning</td><td>Yellow</td></tr>
-				<tr><td>6</td><td>Necrotic</td><td>Black</td></tr>
-				<tr><td>7</td><td>Poison</td><td>Violet</td></tr>
-				<tr><td>8</td><td>Psychic</td><td>Silver</td></tr>
-				<tr><td>9</td><td>Radiant</td><td>Gold</td></tr>
-				<tr><td>10</td><td>Thunder</td><td>Orange</td></tr>
-			</table>			
-			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take damage of the chosen type, you can use your reaction to gain immunity against that instance of the damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p>This tattoo incorporates designs that emphasize green more than others. While the tattoo is on your skin, you have resistance to acid damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take acid damage, you can use your reaction to gain immunity against acid damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
 			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,acid</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Very Rare</set>
 			<set name="attunement">true</set>
 		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_ACID" />
+		</rules>
 	</element>
-	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO">
+	<element name="Absorbing Tattoo, Cold" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_COLD">
 		<description>
-			<p>This tattoo depicts protective imagery and uses ink that resembles liquid metal. While you aren’t wearing armor, the tattoo grants you an Armor Class depending on the tattoo’s rarity, as shown below. You can use a shield and still gain this benefit.</p>
-			<table>
-				<thead>
-					<tr><td>Rarity</td><td>AC</td></tr>
-				</thead>
-				<tr><td>Uncommon</td><td>12 + your Dexterity modifier</td></tr>
-				<tr><td>Rare</td><td>15 + your Dexterity modifier (maximum of +2)</td></tr>
-				<tr><td>Very Rare</td><td>18</td></tr>
-			</table>
+			<p>This tattoo incorporates designs that emphasize blue more than others. While the tattoo is on your skin, you have resistance to cold damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take cold damage, you can use your reaction to gain immunity against cold damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
 			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,cold</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_COLD" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Fire" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_FIRE">
+		<description>
+			<p>This tattoo incorporates designs that emphasize red more than others. While the tattoo is on your skin, you have resistance to fire damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take fire damage, you can use your reaction to gain immunity against fire damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,fire</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_FIRE" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Force" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_FORCE">
+		<description>
+			<p>This tattoo incorporates designs that emphasize white more than others. While the tattoo is on your skin, you have resistance to force damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take force damage, you can use your reaction to gain immunity against force damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,force</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_FORCE" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Lightning" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_LIGHTNING">
+		<description>
+			<p>This tattoo incorporates designs that emphasize yellow more than others. While the tattoo is on your skin, you have resistance to lightning damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take lightning damage, you can use your reaction to gain immunity against lightning damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,lightning</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_LIGHTNING" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Necrotic" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_NECROTIC">
+		<description>
+			<p>This tattoo incorporates designs that emphasize black more than others. While the tattoo is on your skin, you have resistance to necrotic damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take necrotic damage, you can use your reaction to gain immunity against necrotic damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,necrotic</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_NECROTIC" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Poison" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_POISON">
+		<description>
+			<p>This tattoo incorporates designs that emphasize violet more than others. While the tattoo is on your skin, you have resistance to poison damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take poison damage, you can use your reaction to gain immunity against poison damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,poison</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_POISON" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Psychic" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_PSYCHIC">
+		<description>
+			<p>This tattoo incorporates designs that emphasize silver more than others. While the tattoo is on your skin, you have resistance to psychic damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take psychic damage, you can use your reaction to gain immunity against psychic damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,psychic</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_PSYCHIC" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Radiant" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_RADIANT">
+		<description>
+			<p>This tattoo incorporates designs that emphasize gold more than others. While the tattoo is on your skin, you have resistance to radiant damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take radiant damage, you can use your reaction to gain immunity against radiant damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,radiant</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_RADIANT" />
+		</rules>
+	</element>
+	<element name="Absorbing Tattoo, Thunder" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO_THUNDER">
+		<description>
+			<p>This tattoo incorporates designs that emphasize orange more than others. While the tattoo is on your skin, you have resistance to thunder damage.</p>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take thunder damage, you can use your reaction to gain immunity against thunder damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo,thunder</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_THUNDER" />
+		</rules>
+	</element>
+	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO_UNCOMMON">
+		<description>
+			<p>This tattoo depicts protective imagery and uses ink that resembles liquid metal. While you aren’t wearing armor, the tattoo grants you an Armor Class of 12 + your Dexterity modifier. You can use a shield and still gain this benefit.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo, ac, armor class</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Uncommon</set>
 			<set name="attunement">true</set>
 		</setters>
+		<rules>
+			<stat name="ac:uncommon barrier tattoo" value="12" />
+			<stat name="ac:uncommon barrier tattoo" value="dexterity:modifier" />
+			<stat name="ac:calculation" value="ac:uncommon barrier tattoo" bonus="calculation" />
+		</rules>
 	</element>
+	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO_RARE">
+		<description>
+			<p>This tattoo depicts protective imagery and uses ink that resembles liquid metal. While you aren’t wearing armor, the tattoo grants you an Armor Class of 15 + your Dexterity modifier (maximum of +2). You can use a shield and still gain this benefit.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo, ac, armor class</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<stat name="ac:rare barrier tattoo" value="15" />
+			<stat name="ac:rare barrier tattoo" value="dexterity:modifier" max="2" />
+			<stat name="ac:calculation" value="ac:rare barrier tattoo" bonus="calculation" />
+		</rules>
+	</element>
+	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO_VERY_RARE">
+		<description>
+			<p>This tattoo depicts protective imagery and uses ink that resembles liquid metal. While you aren’t wearing armor, the tattoo grants you an Armor Class of 18. You can use a shield and still gain this benefit.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo, ac, armor class</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
+		</setters>
+		<rules>
+			<stat name="ac:very rare barrier tattoo" value="18" />
+			<stat name="ac:calculation" value="ac:very rare barrier tattoo" bonus="calculation" />
+		</rules>
+	</element>	
 	<element name="Coiling Grasp Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_COILING_GRASP_TATTOO">
 		<description>
 			<p>This tattoo has long intertwining designs. While the tattoo is on your skin, you can, as an action, cause the tattoo to extrude into inky tendrils, which reach for a creature you can see within 15 feet of you. The creature must succeed on a DC 14 Strength saving throw or take 3d6 force damage and be grappled by you. As an action, the creature can escape the grapple by succeeding on a DC 14 Strength (Athletics) or Dexterity (Acrobatics) check. The grapple also ends if you halt it (no action required), if the creature is ever more than 15 feet away from you, or if you use this tattoo on a different creature.</p>
@@ -328,7 +512,7 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,force,grappled</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Uncommon</set>
@@ -343,12 +527,16 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,unarmed strike,force</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Uncommon</set>
 			<set name="attunement">true</set>
 		</setters>
+		<rules>
+			<stat name="unarmed strike:attack" value="1" />
+			<stat name="unarmed strike:damage" value="1" />
+		</rules>
 	</element>
 	<element name="Blood Fury Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BLOOD_FURY_TATTOO">
 		<description>
@@ -362,7 +550,7 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,necrotic,hp,reaction</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Legendary</set>
@@ -392,12 +580,15 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,necrotic,resistance</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Rare</set>
 			<set name="attunement">true</set>
 		</setters>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_NECROTIC" />
+		</rules>
 	</element>
 	<element name="Ghost Step Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_GHOST_STEP_TATTOO">
 		<description>
@@ -412,50 +603,102 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,resistance</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Rare</set>
 			<set name="attunement">true</set>
+			<set name="charges">3</set>
 		</setters>
 	</element>
 	<element name="Masquerade Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_MASQUERADE_TATTOO">
 		<description>
 			<p>This tattoo appears on your skin as whatever you desire. As a bonus action, you can shape the tattoo into any color or pattern and move it to any area of your skin. Whatever form it takes, it is always obviously a tattoo. It can range in size from no smaller than a copper piece to an intricate work of art that covers all your skin.</p>
-			<p class="indent"><strong><em>Disguise Self.</em></strong> As an action, you can use the tattoo to cast the disguise self spell. Once the spell is cast from the tattoo, it can’t be cast from the tattoo again until the next dawn.</p>
+			<p class="indent"><strong><em>Disguise Self.</em></strong> As an action, you can use the tattoo to cast the <em>disguise self</em> spell. Once the spell is cast from the tattoo, it can’t be cast from the tattoo again until the next dawn.</p>
 			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
+			<div class="reference">
+				<div element="ID_PHB_SPELL_DISGUISE_SELF" />
+			</div>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,disguise self</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Common</set>
 			<set name="attunement">true</set>
 		</setters>
 	</element>
-	<element name="Spellwrought Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO">
+	<element name="Spellwrought Tattoo, Cantrip" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_CANTRIP">
 		<description>
-			<p>This tattoo contains a single spell of up to 5th level, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
-			<p class="indent">The level of the spell in the tattoo determines the spell’s saving throw DC, attack bonus, spellcasting ability modifier, and the tattoo’s rarity, as shown in the Spellwrought Tattoo table.</p>
-			<h5 class="caption">Spellwrought Tattoo</h5>
-			<table>
-				<thead>
-					<tr><td>Spell Level</td><td>Rarity</td><td>Spellcasting Ability Modifier</td><td>Save DC</td><td>Attack Bonus</td></tr>
-				</thead>
-				<tr><td>Cantrip</td><td>Common</td><td>+3</td><td>13</td><td>+5</td></tr>
-				<tr><td>1st</td><td>Common</td><td>+3</td><td>13</td><td>+5</td></tr>
-				<tr><td>2nd</td><td>Uncommon</td><td>+3</td><td>13</td><td>+5</td></tr>
-				<tr><td>3rd</td><td>Uncommon</td><td>+4</td><td>15</td><td>+7</td></tr>
-				<tr><td>4th</td><td>Rare</td><td>+4</td><td>15</td><td>+7</td></tr>
-				<tr><td>5th</td><td>Rare</td><td>+5</td><td>17</td><td>+9</td></tr>
-			</table>
+			<p>This tattoo contains a single cantrip, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 13, attack bonus is +5, and the spellcasting ability modifier is +3.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo, 1st-level" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_1">
+		<description>
+			<p>This tattoo contains a single 1st-level spell, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 13, attack bonus is +5, and the spellcasting ability modifier is +3.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo, 2nd-level" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_2">
+		<description>
+			<p>This tattoo contains a single 2nd-level spell, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 13, attack bonus is +5, and the spellcasting ability modifier is +3.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Uncommon</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo, 3rd-level" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_3">
+		<description>
+			<p>This tattoo contains a single 3rd-level spell, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 15, attack bonus is +7, and the spellcasting ability modifier is +4.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Uncommon</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo, 4th-level" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_4">
+		<description>
+			<p>This tattoo contains a single 4th-level spell, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 15, attack bonus is +7, and the spellcasting ability modifier is +4.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Rare</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo, 5th-level" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO_5">
+		<description>
+			<p>This tattoo contains a single 5th-level spell, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The spell’s saving throw DC is 17, attack bonus is +9, and the spellcasting ability modifier is +5.</p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Rare</set>
 		</setters>
 	</element>
 	<element name="Shadowfell Brand Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SHADOWFELL_BRAND_TATTOO">
@@ -466,7 +709,7 @@
 			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
-			<set name="keywords">tattoo</set>
+			<set name="keywords">tattoo,stealth</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Very Rare</set>

--- a/unearthed-arcana/2020/20200326.xml
+++ b/unearthed-arcana/2020/20200326.xml
@@ -20,7 +20,358 @@
 		</setters>
 	</element>
 
-
+	<element name="Acid Stream" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_ACID_STREAM">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Evocation</set>
+			<set name="time">time</set>
+			<set name="range">range</set>
+			<set name="duration">duration</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Otherworldly Form" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_OTHERWORLDLY_FORM">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Spirit Shroud" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SPIRIT_SHROUD">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Aberrant Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_ABERRANT_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Bestial Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_BESTIAL_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Celestial Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_CELESTIAL_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Elemental Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_ELEMENTAL_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Fey Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_FEY_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Fiendish Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_FIENDISH_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Shadow Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_SHADOW_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Summon Undead Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_UNDEAD_SPIRIT">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Conjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">true</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
 	
+	<element name="Absorbing Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Coiling Grasp Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_COILING_GRASP_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Eldritch Claw Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ELDRITCH_CLAW_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Blood Fury Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BLOOD_FURY_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Illuminator’s Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ILLUMINATORS_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Lifewell Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_LIFEWELL_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Ghost Step Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_GHOST_STEP_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Masquerade Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_MASQUERADE_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Spellwrought Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
+	<element name="Shadowfell Brand Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SHADOWFELL_BRAND_TATTOO">
+		<description>
+			<p></p>
+			<p class="indent"></p>
+		</description>
+		<setters>
+			<set name="keywords">tattoo</set>
+			<set name="category">Wondrous Items</set>
+			<set name="type">Tattoo</set>
+			<set name="rarity">Common</set>
+		</setters>
+	</element>
 	
 </elements>

--- a/unearthed-arcana/2020/20200326.xml
+++ b/unearthed-arcana/2020/20200326.xml
@@ -21,73 +21,87 @@
 	</element>
 
 	<element name="Acid Stream" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_ACID_STREAM">
-		<supports>supports</supports>
+		<supports>Sorcerer,Wizard</supports>
 		<description>
-			<p></p>
+			<p>A stream of acid emanates from you in a line 30 feet long and 5 feet wide in a direction you choose. Each creature in the line must succeed on a Dexterity saving throw or be covered in acid for the spell’s duration or until a creature uses its action to scrape or wash the acid off itself or another creature. A creature covered in the acid takes 3d4 acid damage at start of each of its turns.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 2nd level or higher, the damage increases by 1d4 for each slot level above 1st.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">1</set>
 			<set name="school">Evocation</set>
-			<set name="time">time</set>
-			<set name="range">range</set>
-			<set name="duration">duration</set>
+			<set name="time">1 action</set>
+			<set name="range">Self (30-foot line)</set>
+			<set name="duration">Concentration, up to 1 minute</set>
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
-			<set name="isConcentration">false</set>
+			<set name="materialComponent">a bit of rotten food</set>
+			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Otherworldly Form" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_OTHERWORLDLY_FORM">
-		<supports>supports</supports>
+		<supports>Cleric,Sorcerer,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>Uttering an incantation, you draw on the magic of the Lower Planes or Upper Planes (your choice) to transform yourself. You gain the following benefits until the spell ends:</p>
+			<ul>
+				<li>You are immune to fire and poison damage (Lower Planes) or radiant and necrotic damage (Upper Planes).</li>
+				<li>You are immune to the poisoned condition (Lower Planes) or the charmed condition (Upper Planes).</li>
+				<li>Spectral wings appear on your back, giving you a flying speed of 40 feet.</li>
+				<li>You have a +2 bonus to AC.</li>
+				<li>All your weapon attacks are magical, and when you make a weapon attack, you can use your spellcasting ability modifier, instead of Strength or Dexterity, for the attack and damage rolls.</li>
+				<li>You can attack twice, instead of once, when you take the Attack action on your turn. You ignore this benefit if you already have a feature, like Extra Attack, that gives you extra attacks.</li>
+			</ul>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Conjuration</set>
+			<set name="level">6</set>
+			<set name="school">Transmutation</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
-			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="duration">Concentration, up to 1 minute</set>
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">an object engraved with a symbol of the Outer Planes, worth at least 500 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Spirit Shroud" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SPIRIT_SHROUD">
-		<supports>supports</supports>
+		<supports>Cleric,Paladin,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth spirits of the dead, which flit around you for the spell’s duration. The spirits are intangible and invulnerable, and they are good or evil (your choice).</p>
+			<p class="indent">Until the spell ends, any attack you make deals 1d8 extra damage when you hit a creature within 10 feet of you. This damage is radiant if the spirits are good and necrotic if they are evil. Any creature that takes this damage can’t regain hit points until the start of your next turn.</p>
+			<p class="indent">In addition, any creature of your choice that you can see that starts its turn within 10 feet of you has its speed reduced by 10 feet until the start of your next turn.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the extra damage increases by 1d8 for each slot level above 3rd.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Conjuration</set>
-			<set name="time">1 action</set>
+			<set name="level">3</set>
+			<set name="school">Necromancy</set>
+			<set name="time">1 bonus action</set>
 			<set name="range">90 feet</set>
-			<set name="duration">Concentration, up to 1 hour</set>
+			<set name="duration">Concentration, up to 1 minute</set>
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
-			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent"></set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Aberrant Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_ABERRANT_SPIRIT">
-		<supports>supports</supports>
+		<supports>Sorcerer,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a spirit from the Far Realm or another alien realm of madness. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Aberrant Spirit stat block below. When you cast the spell, choose Beholderkin, Slaadi, or Star Spawn. The creature physically resembles your choice, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">4</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -95,19 +109,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">a pickled tentacle and an eyeball in a crystal vial worth at least 400 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Bestial Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_BESTIAL_SPIRIT">
-		<supports>supports</supports>
+		<supports>Druid,Ranger</supports>
 		<description>
-			<p></p>
+			<p>You call forth the spirit of a beast. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Bestial Spirit stat block below. When you cast the spell, choose an environment: Air, Land, or Water. The creature physically resembles an animal of your choice that is native to the chosen environment, which also determines one of the movement modes in the creature’s stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 3rd level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">2</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -115,19 +131,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">a feather, tuft of fur, and fish tail inside a gilded acorn worth at least 200 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Celestial Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_CELESTIAL_SPIRIT">
-		<supports>supports</supports>
+		<supports>Cleric,Paladin</supports>
 		<description>
-			<p></p>
+			<p>You call forth a spirit from the Upper Planes. The spirit manifests physically in an angelic form in an unoccupied space that you can see within range. This corporeal form uses the Celestial Spirit stat block below. When you cast the spell, choose Avenger or Defender. Your choice determines the creature’s attack in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 6th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">5</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -135,19 +153,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">a golden reliquary worth at least 500 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Elemental Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_ELEMENTAL_SPIRIT">
-		<supports>supports</supports>
+		<supports>Druid,Sorcerer,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a spirit from the Elemental Planes. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Elemental Spirit stat block below. When you cast the spell, choose an element: Air, Earth, Fire, or Water. The creature physically resembles a vaguely humanoid form wreathed in the chosen element, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">4</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -155,19 +175,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">air, a pebble, ash, and water inside a crystal vial worth at least 400 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Fey Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_FEY_SPIRIT">
-		<supports>supports</supports>
+		<supports>Bard,Druid,Sorcerer,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a spirit from the Feywild. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Fey Spirit stat block below. When you cast the spell, choose a mood: Deceitful, Furious, or Joyful. The creature physically resembles a satyr, a dryad, or an elf (your choice) marked by the chosen mood, which also determines one of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">3</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -175,19 +197,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">a gilded flower worth at least 300 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Fiendish Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_FIENDISH_SPIRIT">
-		<supports>supports</supports>
+		<supports>Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a fiendish spirit from the Lower Planes. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Fiendish Spirit stat block below. When you cast the spell, choose Demon, Devil, or Yugoloth. The creature physically resembles a fiend of the chosen type, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 7th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">6</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -195,19 +219,21 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">humanoid blood inside a ruby vial worth at least 600 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Shadow Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_SHADOW_SPIRIT">
-		<supports>supports</supports>
+		<supports>Sorcerer,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a shadowy spirit from the Shadowfell. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Shadow Spirit stat block below. When you cast the spell, choose an emotion: Fury, Despair, or Fear. The creature physically resembles a misshapen humanoid marked by the chosen emotion, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
+			<set name="level">3</set>
 			<set name="school">Conjuration</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
@@ -215,27 +241,29 @@
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">tears inside a crystal vial worth at least 300 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Summon Undead Spirit" type="Spell" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_SPELL_SUMMON_UNDEAD_SPIRIT">
-		<supports>supports</supports>
+		<supports>Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You call forth a restless spirit from beyond the grave. The spirit manifests physically in an unoccupied space that you can see within range. This corporeal form uses the Undead Spirit stat block below. When you cast the spell, choose the creature’s form: Ghostly, Putrid, or Skeletal. The creature physically resembles a humanoid with the chosen form, which also determines some of the traits in its stat block. The creature disappears when it drops to 0 hit points or when the spell ends.</p>
+			<p class="indent">The creature is friendly to you and your companions for the spell’s duration. In combat, the creature shares your initiative count, but it takes its turn immediately after yours. It obeys verbal commands that you issue to it (no action required by you). If you don’t issue any, it defends itself but otherwise takes no action.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 4th level or higher, the creature assumes the higher level for that casting wherever it uses the spell’s level in its stat block.</p>
 		</description>
 		<setters>
 			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Conjuration</set>
+			<set name="level">3</set>
+			<set name="school">Necromancy</set>
 			<set name="time">1 action</set>
 			<set name="range">90 feet</set>
 			<set name="duration">Concentration, up to 1 hour</set>
 			<set name="hasVerbalComponent">true</set>
 			<set name="hasSomaticComponent">true</set>
 			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
+			<set name="materialComponent">a gilded humanoid skull worth at least 300 gp</set>
 			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
@@ -243,116 +271,185 @@
 	
 	<element name="Absorbing Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ABSORBING_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo incorporates designs that emphasize one color more than others. While the tattoo is on your skin, you have resistance to a type of damage associated with that color, as shown on the table below. The DM chooses the color or determines it randomly.</p>
+			<table>
+				<thead>
+					<tr><td>d10</td><td>Damage Type</td><td>Color</td></tr>
+				</thead>
+				<tr><td>1</td><td>Acid</td><td>Green</td></tr>
+				<tr><td>2</td><td>Cold</td><td>Blue</td></tr>
+				<tr><td>3</td><td>Fire</td><td>Red</td></tr>
+				<tr><td>4</td><td>Force</td><td>White</td></tr>
+				<tr><td>5</td><td>Lightning</td><td>Yellow</td></tr>
+				<tr><td>6</td><td>Necrotic</td><td>Black</td></tr>
+				<tr><td>7</td><td>Poison</td><td>Violet</td></tr>
+				<tr><td>8</td><td>Psychic</td><td>Silver</td></tr>
+				<tr><td>9</td><td>Radiant</td><td>Gold</td></tr>
+				<tr><td>10</td><td>Thunder</td><td>Orange</td></tr>
+			</table>			
+			<p class="indent"><strong><em>Damage Absorption.</em></strong> When you take damage of the chosen type, you can use your reaction to gain immunity against that instance of the damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Barrier Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BARRIER_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo depicts protective imagery and uses ink that resembles liquid metal. While you aren’t wearing armor, the tattoo grants you an Armor Class depending on the tattoo’s rarity, as shown below. You can use a shield and still gain this benefit.</p>
+			<table>
+				<thead>
+					<tr><td>Rarity</td><td>AC</td></tr>
+				</thead>
+				<tr><td>Uncommon</td><td>12 + your Dexterity modifier</td></tr>
+				<tr><td>Rare</td><td>15 + your Dexterity modifier (maximum of +2)</td></tr>
+				<tr><td>Very Rare</td><td>18</td></tr>
+			</table>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Uncommon</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Coiling Grasp Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_COILING_GRASP_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo has long intertwining designs. While the tattoo is on your skin, you can, as an action, cause the tattoo to extrude into inky tendrils, which reach for a creature you can see within 15 feet of you. The creature must succeed on a DC 14 Strength saving throw or take 3d6 force damage and be grappled by you. As an action, the creature can escape the grapple by succeeding on a DC 14 Strength (Athletics) or Dexterity (Acrobatics) check. The grapple also ends if you halt it (no action required), if the creature is ever more than 15 feet away from you, or if you use this tattoo on a different creature.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Uncommon</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Eldritch Claw Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ELDRITCH_CLAW_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo depicts clawlike forms and other jagged shapes. While the tattoo is on your skin, your unarmed strikes are considered magical for the purpose of overcoming immunity and resistance to nonmagical attacks, and you gain a +1 bonus to attack and damage rolls with unarmed strikes.</p>
+			<p class="indent"><strong><em>Eldritch Maul.</em></strong> As a bonus action, you can empower the tattoo for 1 minute. For the duration, each of your melee weapon attacks can reach a target up to 30 feet away from you, as tendrils of ink launch from your weapon or unarmed strike toward the target. In addition, your melee weapon attacks deal an extra 1d6 force damage on a hit. Once used, this bonus action can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Uncommon</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Blood Fury Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_BLOOD_FURY_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo evokes fury in its form and colors. While this tattoo is on your skin, you gain the following benefits:</p>
+			<ul>
+				<li>Your attack rolls score a critical hit on a d20 roll of 19 or 20.</li>
+				<li>When you score a critical hit against a creature, that target takes an extra 4d6 necrotic damage, and you gain a number of temporary hit points equal to the necrotic damage dealt.</li>
+				<li>When a creature you can see damages you, you can use your reaction to make a melee attack against that creature, with advantage on your attack roll.</li>
+			</ul>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Legendary</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Illuminator’s Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_ILLUMINATORS_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo contains beautiful calligraphy, images of writing implements, and the like. While this tattoo is on your skin, you can write with your fingertip as if it were an ink pen that never runs out of ink.</p>
+			<p class="indent">As an action, you can touch a piece of writing up to one page in length and speak a creature’s name. The writing becomes invisible to everyone other than you and the named creature for the next 24 hours. Either of you can dismiss the invisibility by touching the script (no action required). Once used, this action can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Common</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Lifewell Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_LIFEWELL_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo comprises symbols of life and rebirth. While this tattoo is on your skin, you have resistance to necrotic damage.</p>
+			<p class="indent"><strong><em>Death Ward.</em></strong> When you would be reduced to 0 hit points, you drop to 1 hit point instead. Once used, this benefit can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Rare</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Ghost Step Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_GHOST_STEP_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo shifts and wavers on the skin, parts of it appearing blurred. The tattoo has 3 charges, and it regains all expended charges daily at dawn.</p>
+			<p class="indent">As a bonus action while the tattoo is on your skin, you can expend 1 of the tattoo’s charges to become incorporeal until the end of your next turn. For the duration, you gain the following benefits:</p>
+			<ul>
+				<li>You have resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks.</li>
+				<li>You can’t be grappled or restrained.</li>
+				<li>You can move through creatures and solid objects as if they were difficult terrain. If you end your turn in a solid object, you take 1d10 force damage. If the effect ends while you are inside a solid object, you instead are shunted to the nearest unoccupied space, and you take 1d10 force damage for every 5 feet traveled.</li>
+			</ul>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Rare</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Masquerade Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_MASQUERADE_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo appears on your skin as whatever you desire. As a bonus action, you can shape the tattoo into any color or pattern and move it to any area of your skin. Whatever form it takes, it is always obviously a tattoo. It can range in size from no smaller than a copper piece to an intricate work of art that covers all your skin.</p>
+			<p class="indent"><strong><em>Disguise Self.</em></strong> As an action, you can use the tattoo to cast the disguise self spell. Once the spell is cast from the tattoo, it can’t be cast from the tattoo again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
 			<set name="rarity">Common</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	<element name="Spellwrought Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SPELLWROUGHT_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo contains a single spell of up to 5th level, wrought on your skin by a magic needle. To use the tattoo, you must hold the needle against your skin where you want the tattoo to appear and speak the command word. The needle turns into the ink that becomes the tattoo, which appears on your skin. Once the tattoo is on your skin, you can cast its spell, requiring no material components. The tattoo glows faintly while you cast the spell and for the spell’s duration. Once the spell ends, the tattoo vanishes from your skin.</p>
+			<p class="indent">The level of the spell in the tattoo determines the spell’s saving throw DC, attack bonus, spellcasting ability modifier, and the tattoo’s rarity, as shown in the Spellwrought Tattoo table.</p>
+			<h5 class="caption">Spellwrought Tattoo</h5>
+			<table>
+				<thead>
+					<tr><td>Spell Level</td><td>Rarity</td><td>Spellcasting Ability Modifier</td><td>Save DC</td><td>Attack Bonus</td></tr>
+				</thead>
+				<tr><td>Cantrip</td><td>Common</td><td>+3</td><td>13</td><td>+5</td></tr>
+				<tr><td>1st</td><td>Common</td><td>+3</td><td>13</td><td>+5</td></tr>
+				<tr><td>2nd</td><td>Uncommon</td><td>+3</td><td>13</td><td>+5</td></tr>
+				<tr><td>3rd</td><td>Uncommon</td><td>+4</td><td>15</td><td>+7</td></tr>
+				<tr><td>4th</td><td>Rare</td><td>+4</td><td>15</td><td>+7</td></tr>
+				<tr><td>5th</td><td>Rare</td><td>+5</td><td>17</td><td>+9</td></tr>
+			</table>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
@@ -363,14 +460,17 @@
 	</element>
 	<element name="Shadowfell Brand Tattoo" type="Magic Item" source="Unearthed Arcana: Spells and Magic Tattoos" id="ID_WOTC_UA20200326_MAGIC_ITEM_SHADOWFELL_BRAND_TATTOO">
 		<description>
-			<p></p>
-			<p class="indent"></p>
+			<p>This tattoo is dark in color and abstract. While it’s on your skin, you have advantage on Dexterity (Stealth) checks.</p>
+			<p class="indent"><strong><em>Shadowy Defense.</em></strong> When you take damage, you can use your reaction to become shadowy and insubstantial for a moment, reducing the damage you take by half. Once used, this reaction can’t be used again until the next dawn.</p>
+			<p class="indent"><strong><em>Tattoo Attunement.</em></strong> To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin. If you have multiple magic tattoos, they count as a single magic item with regard to the number of magic items you can attune to.</p>
+			<p class="indent">If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in the closest unoccupied space to you.</p>
 		</description>
 		<setters>
 			<set name="keywords">tattoo</set>
 			<set name="category">Wondrous Items</set>
 			<set name="type">Tattoo</set>
-			<set name="rarity">Common</set>
+			<set name="rarity">Very Rare</set>
+			<set name="attunement">true</set>
 		</setters>
 	</element>
 	


### PR DESCRIPTION
**Spells**

- [x] Acid Stream
- [x] Otherworldly Form
- [x] Spirit Shroud
- [x] Summon Aberrant Spirit
- [x] Summon Bestial Spirit
- [x] Summon Celestial Spirit
- [x] Summon Elemental Spirit
- [x] Summon Fey Spirit
- [x] Summon Fiendish Spirit
- [x] Summon Shadow Spirit
- [x] Summon Undead Spirit

**Magic Tattoos**

- [x] Absorbing Tattoo
- [x] Barrier Tattoo
- [x] Coiling Grasp Tattoo
- [x] Eldritch Claw Tattoo
- [x] Blood Fury Tattoo
- [x] Illuminator’s Tattoo
- [x] Lifewell Tattoo
- [x] Ghost Step Tattoo
- [x] Masquerade Tattoo
- [x] Spellwrought Tattoo
- [x] Shadowfell Brand Tattoo

Source: https://dnd.wizards.com/articles/unearthed-arcana/spells-magic-tattoos
