### PR TITLE
[PHB] Dragonborn: Breath Weapon Saves fix

### DIFF
--- a/core/players-handbook/races/race-dragonborn.xml
+++ b/core/players-handbook/races/race-dragonborn.xml
@@ -4,7 +4,7 @@
 		<name>Dragonborn</name>
 		<description></description>
 		<author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-		<update version="0.2.2">
+		<update version="0.2.3">
 			<file name="race-dragonborn.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/races/race-dragonborn.xml" />
 		</update>
 	</info>
@@ -91,10 +91,10 @@
 				<tr><td>Bronze</td><td>Lightning</td><td>5 by 30 ft. line (Dex. save)</td></tr>
 				<tr><td>Copper</td><td>Acid</td><td>5 by 30 ft. line (Dex. save)</td></tr>
 				<tr><td>Gold</td><td>Fire</td><td>15 ft. cone (Dex. save)</td></tr>
-				<tr><td>Green</td><td>Poison</td><td>15 ft. cone (Dex. save)</td></tr>
+				<tr><td>Green</td><td>Poison</td><td>15 ft. cone (Con. save)</td></tr>
 				<tr><td>Red</td><td>Fire</td><td>15 ft. cone (Dex. save)</td></tr>
-				<tr><td>Silver</td><td>Cold</td><td>15 ft. cone (Dex. save)</td></tr>
-				<tr><td>White</td><td>Cold</td><td>15 ft. cone (Dex. save)</td></tr>
+				<tr><td>Silver</td><td>Cold</td><td>15 ft. cone (Con. save)</td></tr>
+				<tr><td>White</td><td>Cold</td><td>15 ft. cone (Con. save)</td></tr>
 			</table>
 		</description>
 		<rules>
@@ -232,7 +232,7 @@
 		<rules>
 			<stat inline="true" name="draconic-ancestry" value="Green"/>
 			<stat inline="true" name="draconic-ancestry:damage type" value="Poison" />
-			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Dex. save)" />
+			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Con. save)" />
 		</rules>
 	</element>
 	<element name="Draconic Ancestry (Red)" type="Racial Trait" source="Player’s Handbook" id="ID_RACIAL_TRAIT_DRACONIC_ANCESTRY_RED">
@@ -260,7 +260,7 @@
 		<rules>
 			<stat inline="true" name="draconic-ancestry" value="Silver"/>
 			<stat inline="true" name="draconic-ancestry:damage type" value="Cold" />
-			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Dex. save)" />
+			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Con. save)" />
 		</rules>
 	</element>
 	<element name="Draconic Ancestry (White)" type="Racial Trait" source="Player’s Handbook" id="ID_RACIAL_TRAIT_DRACONIC_ANCESTRY_WHITE">
@@ -274,7 +274,7 @@
 		<rules>
 			<stat inline="true" name="draconic-ancestry" value="White"/>
 			<stat inline="true" name="draconic-ancestry:damage type" value="Cold" />
-			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Dex. save)" />
+			<stat inline="true" name="draconic-ancestry:breath" value="15 ft. cone (Con. save)" />
 		</rules>
 	</element>
 </elements>


### PR DESCRIPTION
• Breath Weapon Saves of Green, Silver and White Dragonborns changed to Constitution.