### PR TITLE
UA20200414 Psionic Options Revisited

### DIFF
--- a/unearthed-arcana.index
+++ b/unearthed-arcana.index
@@ -4,7 +4,7 @@
 		<name>Unearthed Arcana</name>
 		<description>The material presented in Unearthed Arcana will range from mechanics that we expect one day to publish in a supplement to house rules from our home campaigns that we want to share, from core system options to setting-specific material. Once it’s out there, you can expect us to check in with you to see how it’s working out and what we can do to improve it.</description>
 		<author url="http://dnd.wizards.com/articles/unearthed-arcana">Wizards of the Coast</author>
-		<update version="0.6.1">
+		<update version="0.6.2">
 			<file name="unearthed-arcana.index" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana.index" />
 		</update>
 	</info>
@@ -96,6 +96,7 @@
 		<!-- <file name="20200206.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200206.xml" /> -->
 		<file name="20200224.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200224.xml" />
 		<file name="20200326.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200326.xml" />
+		<file name="20200414.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200414.xml" />
 
 	</files>
 </index>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -591,6 +591,9 @@
 				<li>You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is the ability increased by this feat.</li>
 				<li>As a bonus action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, roll your Psionic Talent die, and the target must succeed on a Strength saving throw (DC 8 + your proficiency bonus + the ability modifier of the score increased by this feat) or be moved toward you or away from you a number of feet equal to 5 times the number you rolled. A creature can willingly fail this save.</li>
 			</ul>
+			<div class="reference">
+				<div element="ID_PHB_SPELL_MAGE_HAND" />
+			</div>
 		</description>
 		<sheet>
 			<description>You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is {{ua:telekinetic:ability}}.
@@ -666,6 +669,9 @@
 				<li>You can speak telepathically to any creature you can see within 30 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn’t give the creature the ability to respond to you telepathically.</li>
 				<li>If your Psionic Talent die is available, you can cast the detect thoughts spell, requiring no components. When you start casting the spell, your Psionic Talent die decreases by one die size. Your spellcasting ability for the spell is the ability increased by this feat.</li>
 			</ul>
+			<div class="reference">
+				<div element="ID_PHB_SPELL_DETECT_THOUGHTS" />
+			</div>
 		</description>
 		<sheet>
 			<description>You can speak telepathically to any creature you can see within 30 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn’t give the creature the ability to respond to you telepathically.
@@ -738,9 +744,12 @@
 		<description>
 			<p>You awaken to your psionic potential, which enhances your mind or body. Increase one ability score of your choice by 1, to a maximum of 20, to represent this enhancement.</p>
 			<p class="indent">You also harbor a wellspring of psionic power within yourself, an energy that ebbs and flows as you channel it in various ways. This power is represented by your Psionic Talent die, the starting size of which is a d6.</p>
-			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>			
-			<p class=""><strong>Psi-Boosted Ability.</strong> When you make an ability check with the ability increased by this feat, you can roll your Psionic Talent die and add the number rolled to the check. You can choose to do so before or after rolling the d20, but before you know whether the check succeeded or failed.</p>
-			<p class=""><strong>Psi-Guided Strike.</strong> Once on each of your turns when you hit with an attack roll that uses the ability increased by this feat, you can roll your Psionic Talent die after you make the damage roll and then replace one of the damage dice with the number rolled on the Psionic Talent die.</p>
+			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>
+			<ul class="unstyled mb">
+				<li><strong>Psi-Boosted Ability.</strong> When you make an ability check with the ability increased by this feat, you can roll your Psionic Talent die and add the number rolled to the check. You can choose to do so before or after rolling the d20, but before you know whether the check succeeded or failed.</li>
+				<li><strong>Psi-Guided Strike.</strong> Once on each of your turns when you hit with an attack roll that uses the ability increased by this feat, you can roll your Psionic Talent die after you make the damage roll and then replace one of the damage dice with the number rolled on the Psionic Talent die.</li>
+			</ul>
+			<br />
 			<p class="indent"><strong><em>Changing the Die’s Size.</em></strong> If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. This represents you burning through your psionic energy. For example, if the die is a d6 and you roll a 6, it becomes a d4. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.</p>
 			<p class="indent">Conversely, if you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size. This represents you conserving psionic energy for later use. For example, if you roll a 1 on a d4, the die then becomes a d6.</p>
 			<p class="indent">Whenever you finish a long rest, your Psionic Talent die resets to its starting size. When you reach certain levels, the starting size of your Psionic Talent die increases: at 5th level (d8), 11th level (d10), and 17th level (d12).</p>
@@ -791,7 +800,5 @@
 		</sheet>
 	</element>
 
-	<!-- todo: replace with official if ever published in this form -->
 	<element name="Psionic Talent feature" type="Grants" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
-
 </elements>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<elements>
+	<info>
+		<name>Unearthed Arcana: Psionic Options Revisited</name>
+		<update version="0.0.1">
+			<file name="20200414.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/unearthed-arcana/2020/20200414.xml" />
+		</update>
+	</info>	
+	<element name="Unearthed Arcana: Psionic Options Revisited" type="Source" source="Core" id="ID_WOTC_SOURCE_UNEARTHED_ARCANA_20200414">
+		<description>
+			<p>Shine with the power of the mind in this installment of Unearthed Arcana! Today we revisit several psi-themed options that we released in the past few months. Studying your feedback on those options, we’ve crafted this new collection of subclasses, spells, and feats.</p>
+		</description>
+		<setters>
+			<set name="abbreviation">UA20200414</set>
+			<set name="url">https://dnd.wizards.com/articles/unearthed-arcana/psionic-options-revisited</set>
+			<set name="author" abbreviation="WOTC" url="http://dnd.wizards.com">Wizards of the Coast</set>
+			<set name="official">true</set>
+			<set name="playtest">true</set>
+			<set name="release">20200414</set>
+		</setters>
+	</element>
+
+	<element name="Psi Knight" type="Archetype" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FIGHTER_PSI_KNIGHT">
+		<supports>Martial Archetype</supports>
+		<description>
+			<p>Awake to the psionic power within, a Psi Knight is a fighter who augments their physical might with psi-infused weapon strikes, telekinetic lashes, and barriers of mental force. Many githyanki train to become such knights, as do some of the most disciplined high elves. In the world of Athas, renowned gladiators in the arenas of the Sorcerer-Kings are often Psi Knights, and in Eberron, the psionic kalashtar view membership in this knighthood as a special honor.</p>
+			<p class="indent">As a Psi Knight, you might have honed your psionic abilities through solo discipline, unlocked it under the tutelage of a master, or refined it at an academy dedicated to wielding the mind’s power as both weapon and shield.</p>
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_BULWARK_OF_FORCE" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_MASTER" />
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT" level="3" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT" level="7" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM" level="10" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_BULWARK_OF_FORCE" level="15" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_MASTER" level="18" />
+		</rules>
+	</element>
+	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT">
+		<description>
+			<p><em>3rd-level Psi Knight feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Telekinetic Adept" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT">
+		<description>
+			<p><em>7th-level Psi Knight feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Psi-Enhanced Metabolism" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM">
+		<description>
+			<p><em>10th-level Psi Knight feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Bulwark of Force" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_BULWARK_OF_FORCE">
+		<description>
+			<p><em>15th-level Psi Knight feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Telekinetic Master" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_MASTER">
+		<description>
+			<p><em>18th-level Psi Knight feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+
+	<element name="Soulknife" type="Archetype" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_SOULKNIFE">
+		<supports>Roguish Archetype</supports>
+		<description>
+			<p>Most assassins strike with physical weapons, and many burglars and spies use thieves’ tools to infiltrate secure locations, whereas a Soulknife strikes and infiltrates with the mind, cutting through barriers both physical and psychic. These rogues discover psionic power within themselves and channel it to do their roguish work. They find easy employment as members of thieves’ guilds, though they are often mistrusted by rogues who are leery of anyone using strange mind powers to conduct their business, and most governments would be happy to employ a Soulknife as a spy.</p>
+			<p class="indent">Amid the trees of ancient forests on the Material Plane and in the Feywild, some wood elves walk the path of the Soulknife, serving as silent, lethal guardians of their woods. In the endless war among the gith, a githzerai is encouraged to become a Soulknife when stealth is required against the githyanki foe, and in the world of Athas, a Sorcerer-King often turns to a Soulknife to eliminate an enemy, just as an insurgent Soulknife seeks to undermine that Sorcerer-King’s rule.</p>
+			<p class="indent">As a Soulknife, your psionic abilities might have haunted you since you were a child, only revealing their potential as you experienced the stress of adventure. Or you might have sought out a reclusive order of psionic adepts and spent years learning how to manifest your power.</p>
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_REND_MIND" />
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT" level="3" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES" level="3" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES" level="9" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL" level="13" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_REND_MIND" level="17" />
+		</rules>
+	</element>
+	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT">
+		<description>
+			<p><em>3rd-level Soulknife feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Psychic Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES">
+		<description>
+			<p><em>3rd-level Soulknife feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Soul Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES">
+		<description>
+			<p><em>9th-level Soulknife feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Psionic Veil" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL">
+		<description>
+			<p><em>13th-level Soulknife feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Rend Mind" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_REND_MIND">
+		<description>
+			<p><em>17th-level Soulknife feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+
+	<element name="Psionic Soul" type="Archetype" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_SORCERER_PSIONIC_SOUL">
+		<supports>Sorcerous Origin</supports>
+		<description>
+			<p>One day a light blazed forth within you—the illumination of psionic power. Your mind now simmers with this power, the full extent of which you won’t fully grasp for years to come. You can touch other minds with it and alter the world around you by using it to control the magical energy of the multiverse. Will this power shine from you as a hopeful beacon to others? Or will you be a source of terror to those who feel the stab of your mind and witness the strange manifestations of your might?</p>
+			<p class="indent">Among githyanki and githzerai, the powers of Psionic Soul sorcerers are revered and marshaled on both sides of the gith war. In Eberron, many kalashtar dream of discovering this origin’s abilities within themselves, and in Athas, more sorcerers are born with a Psionic Soul than with any other source of power. In the glades of primeval woods touched by the Feywild, children sometimes awaken to the wonders of psionic power. And in communities that survive Far Realm incursions, some folk are mutated into horrific aberrations, while a lucky few not only remain themselves, but also discover that psionic energy now suffuses their minds.</p>
+			<p class="indent">As a Psionic Soul sorcerer, you decide how you acquired your powers. Were you born with them, and did they manifest throughout childhood? Or did an extraordinary event later in life leave you shining with psionic awareness? Consult the Psionic Origins table for a possible origin of your power.</p>
+			<h5 class="caption">Psionic Origins</h5>
+			<table>
+				<thead>
+					<tr><td>d10</td><td>Origin</td></tr>
+				</thead>
+				<tr><td>1</td><td>You were exposed to the Far Realm’s warping influence. You can now use your mind in ways you never thought possible, and you’re also convinced that a tendril is growing upon you.</td></tr>
+				<tr><td>2</td><td>A psychic wind from the Astral Plane carried psionic energy into your being. When you use your powers now, faint motes of light sparkle around you.</td></tr>
+				<tr><td>3</td><td>You or your ancestor were trained by a githzerai monk to unlock the psionic potential within yourself.</td></tr>
+				<tr><td>4</td><td>A spirit haunts your mind, lending incredible power to your thoughts. When you sleep, the spirit’s memories invade your dreams.</td></tr>
+				<tr><td>5</td><td>Deep in a forest touched by the Feywild, you drank from a glimmering stream, and now your mind shines with power. Beasts and fey creatures are often now friendly to you, as if they can sense the light within you.</td></tr>
+				<tr><td>6</td><td>Upon recovering from a near-fatal injury, you found yourself with psionic powers. Whenever you use them, your old wound tingles.</td></tr>
+				<tr><td>7</td><td>You were implanted with a mind flayer tadpole, but the ceremorphosis never completed. And now the psionic power is yours. When you use it, your flesh shines with a strange mucus.</td></tr>
+				<tr><td>8</td><td>As a child, you had an imaginary friend that looked like a flumph or a strange platypuslike creature. One day, it gifted you with psionic powers, which have ended up being not so imaginary.</td></tr>
+				<tr><td>9</td><td>Your nightmares whisper the truth to you: your psionic powers are not your own. You draw them from your vestigial twin!</td></tr>
+				<tr><td>10</td><td>You grew up near the lair of a sapphire dragon, and now your eyes glow with sapphire light when you use your newfound powers.</td></tr>
+			</table>
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_MIND_OVER_BODY" />
+			<div element="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_AURA" />
+		</description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT" level="1" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE" level="6" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_MIND_OVER_BODY" level="14" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_AURA" level="18" />
+		</rules>
+	</element>
+	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT">
+		<description>
+			<p><em>1st-level Psionic Soul feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Psychic Strike" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE">
+		<description>
+			<p><em>6th-level Psionic Soul feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Mind Over Body" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_MIND_OVER_BODY">
+		<description>
+			<p><em>14th-level Psionic Soul feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Psychic Aura" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_AURA">
+		<description>
+			<p><em>18th-level Psionic Soul feature</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+
+	<element name="Intellect Fortress" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_INTELLECT_FORTRESS">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Evocation</set>
+			<set name="time">time</set>
+			<set name="range">range</set>
+			<set name="duration">duration</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Mind Sliver" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_MIND_SLIVER">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Evocation</set>
+			<set name="time">time</set>
+			<set name="range">range</set>
+			<set name="duration">duration</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+	<element name="Mind Thrust" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_MIND_THRUST">
+		<supports>supports</supports>
+		<description>
+			<p></p>
+		</description>
+		<setters>
+			<set name="keywords"></set>
+			<set name="level">level</set>
+			<set name="school">Evocation</set>
+			<set name="time">time</set>
+			<set name="range">range</set>
+			<set name="duration">duration</set>
+			<set name="hasVerbalComponent">true</set>
+			<set name="hasSomaticComponent">true</set>
+			<set name="hasMaterialComponent">true</set>
+			<set name="materialComponent">component</set>
+			<set name="isConcentration">false</set>
+			<set name="isRitual">false</set>
+		</setters>
+	</element>
+
+	<element name="Metabolic Control" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_METABOLIC_CONTROL">
+		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
+		<requirements></requirements>
+		<description>
+			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Telekinetic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEKINETIC">
+		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
+		<requirements></requirements>
+		<description>
+			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Telepathic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEPATHIC">
+		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
+		<requirements></requirements>
+		<description>
+			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Tower of Iron Will" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TOWER_OF_IRON_WILL">
+		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
+		<requirements></requirements>
+		<description>
+			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+	<element name="Wild Talent" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_WILD_TALENT">
+		<description>
+			<p></p>
+		</description>
+		<sheet>
+			<description></description>
+		</sheet>
+	</element>
+
+</elements>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -57,9 +57,69 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>Your Psionic Talent die is a d{{ua:psi-knight:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
+			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:psi-knight:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psi-knight:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psi-knight:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psi-knight:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_REPLENISHMENT" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PROTECTIVE_FIELD" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_POWERED_LEAP" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_STRIKE" />
+		</rules>
+	</element>
+
+	<element name="Protective Field" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PROTECTIVE_FIELD">
+		<compendium display="false" />
+		<description>
+			<p>When you or another creature you can see within 30 feet of you takes damage, you can use your reaction to roll your Psionic Talent die and reduce the damage taken by the number rolled plus your Intelligence modifier (minimum reduction of 1), as you create a momentary shield of telekinetic force.</p>
+		</description>
+		<sheet action="Reaction" usage="Psionic Talent">
+			<description>When you or another creature you can see within 30 feet of you takes damage, you can roll your Psionic Talent die and reduce the damage taken by the number rolled plus {{ua:protective-field:usage}}.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:protective-field:usage" value="1" bonus="base" />
+			<stat name="ua:protective-field:usage" value="intelligence:modifier" bonus="base" />
+		</rules>
+	</element>
+	<element name="Psi-Powered Leap" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_POWERED_LEAP">
+		<compendium display="false" />
+		<description>
+			<p>When you make a high or long jump, you can roll your Psionic Talent die and extend the distance of the jump, up to a number of feet equal to twice the number rolled plus twice your Intelligence modifier (minimum of 1 extra foot). This extra distance costs you only 1 foot of movement.</p>
+		</description>
+		<sheet usage="Psionic Talent">
+			<description>When you make a high or long jump, you can roll your Psionic Talent die and extend the distance of the jump, up to a number of feet equal to twice the number rolled plus {{ua:psi-powered-leap:usage}}. This extra distance costs you only 1 foot of movement.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:psi-powered-leap:ability" value="intelligence:modifier" />
+			<stat name="ua:psi-powered-leap:ability" value="intelligence:modifier" />
+			<stat name="ua:psi-powered-leap:usage" value="1" bonus="base" />
+			<stat name="ua:psi-powered-leap:usage" value="ua:psi-powered-leap:ability" bonus="base" />
+		</rules>
+	</element>
+	<element name="Telekinetic Strike" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_STRIKE">
+		<compendium display="false" />
+		<description>
+			<p>You can propel your attacks with telekinetic force. Once on each of your turns, immediately after you deal damage to a target within 30 feet of you with a weapon attack, you can roll your Psionic Talent die and also deal force damage to the target equal to the number rolled.</p>
+		</description>
+		<sheet usage="Psionic Talent">
+			<description>Once on each of your turns, immediately after you deal damage to a target within 30 feet of you with a weapon attack, you can roll your Psionic Talent die and also deal force damage to the target equal to the number rolled.</description>
 		</sheet>
 	</element>
+	<element name="Psi Replenishment" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_REPLENISHMENT">
+		<compendium display="false" />
+		<description>
+			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="1/Long Rest">
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psi-knight:psionic-talent-die:size}}).</description>
+		</sheet>
+	</element>
+
 	<element name="Telekinetic Adept" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT">
 		<description>
 			<p><em>7th-level Psi Knight feature</em></p>
@@ -69,18 +129,46 @@
 				<li><strong>Telekinetic Movement.</strong> If your Psionic Talent die is available, you can move an object or a creature with your mind. As an action, you target one loose object that is Large or smaller or one willing creature, other than yourself. If you can see the target and it is within 30 feet of you, you can move it up to 30 feet to an unoccupied space you can see. Alternatively, if it is a Tiny object, you can move it to or from your hand. Either way, you can move the target horizontally, vertically, or both. When you take this action, your Psionic Talent die decreases by one die size.</li>
 			</ul>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT_PSIONIC_THRUST" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT_TELEKINETIC_MOVEMENT" />
+		</rules>
+	</element>
+	<element name="Psionic Thrust" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT_PSIONIC_THRUST">
+		<description>
+			<p>When you deal damage to a target with the Telekinetic Strike of your Psionic Talent, you can force the target to make a Strength saving throw against a DC equal to 8 + your proficiency bonus + your Intelligence modifier. Unless the save succeeds, you can knock the target prone or move it up to 10 feet in any direction horizontally.</p>
+		</description>
+		<sheet usage="Telekinetic Adept">
+			<description>When you deal damage to a target with the Telekinetic Strike, you can force the target to make a Strength save against a DC {{ua:psionic thrust:dc}}. Unless the save succeeds, you can knock the target prone or move it up to 10 feet in any direction horizontally.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:psionic thrust:dc" value="8" />
+			<stat name="ua:psionic thrust:dc" value="proficiency" />
+			<stat name="ua:psionic thrust:dc" value="intelligence:modifier" />
+		</rules>
+	</element>
+	<element name="Telekinetic Movement" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT_TELEKINETIC_MOVEMENT">
+		<description>
+			<p>If your Psionic Talent die is available, you can move an object or a creature with your mind. As an action, you target one loose object that is Large or smaller or one willing creature, other than yourself. If you can see the target and it is within 30 feet of you, you can move it up to 30 feet to an unoccupied space you can see. Alternatively, if it is a Tiny object, you can move it to or from your hand. Either way, you can move the target horizontally, vertically, or both. When you take this action, your Psionic Talent die decreases by one die size.</p>
+		</description>
+		<sheet action="Action" usage="Telekinetic Adept">
+			<description>If your Psionic Talent die is available, you can move an object or a creature with your mind. You target one loose object that is Large or smaller or one willing creature, other than yourself. If you can see the target and it is within 30 feet of you, you can move it up to 30 feet to an unoccupied space you can see. Alternatively, if it is a Tiny object, you can move it to or from your hand. Either way, you can move the target horizontally, vertically, or both. When you take this action, your Psionic Talent die decreases by one die size.</description>
 		</sheet>
 	</element>
+
 	<element name="Psi-Enhanced Metabolism" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM">
 		<description>
 			<p><em>10th-level Psi Knight feature</em></p>
 			<p>The psionic energy flowing through you has bolstered your mind and body. You have resistance to poison and psychic damage, and you are immune to the poisoned condition.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>You have resistance to poison and psychic damage, and you are immune to the poisoned condition.</description>
 		</sheet>
+		<rules>
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_POISON" />
+			<grant type="Condition" id="ID_INTERNAL_CONDITION_DAMAGE_RESISTANCE_PSYCHIC" />
+		</rules>
 	</element>
 	<element name="Bulwark of Force" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_BULWARK_OF_FORCE">
 		<description>
@@ -88,17 +176,25 @@
 			<p>You can shield yourself and others with telekinetic force. As a bonus action, you can choose creatures, which can include you, that you can see within 30 feet of you, up to a number of creatures equal to your Intelligence modifier (minimum of one creature). Each of the chosen creatures is protected by half cover for 1 minute or until you’re incapacitated.</p>
 			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet action="Bonus Action" usage="1/Long Rest">
+			<description>You can choose up to {{bulwark of force:creatures}} creatures, which can include you, that you can see within 30 feet of you. Each of the chosen creatures is protected by half cover for 1 minute or until you’re incapacitated.
+			Decrease your Psionic Talent die by one die size to use this feature again.</description>
 		</sheet>
+		<rules>
+			<stat name="bulwark of force:creatures" value="1" bonus="base" />
+			<stat name="bulwark of force:creatures" value="intelligence:modifier" bonus="base" />
+		</rules>
 	</element>
 	<element name="Telekinetic Master" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_MASTER">
 		<description>
 			<p><em>18th-level Psi Knight feature</em></p>
 			<p>Your ability to move creatures and objects with your mind is matched by few. If your Psionic Talent die is available, you can cast the telekinesis spell, requiring no components. Your spellcasting ability for the spell is Intelligence. When you cast this spell, your Psionic Talent die decreases by one die size.</p>
+			<div class="reference">
+				<div element="ID_PHB_SPELL_TELEKINESIS" />
+			</div>
 		</description>
 		<sheet>
-			<description></description>
+			<description>If your Psionic Talent die is available, you can cast the telekinesis spell, requiring no components, using Intelligence as your spellcasting ability. When you cast this spell, your Psionic Talent die decreases by one die size.</description>
 		</sheet>
 	</element>
 
@@ -139,9 +235,48 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>Your Psionic Talent die is a d{{ua:soulknife:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
+			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:soulknife:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:soulknife:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:soulknife:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:soulknife:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_REPLENISHMENT" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_BOLSTERED_KNACK" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_WHISPERS" />
+		</rules>
+	</element>
+	<element name="Psi-Bolstered Knack" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_BOLSTERED_KNACK">
+		<compendium display="false" />
+		<description>
+			<p>When your non-psionic training fails you, you can tap into your psionic power to help: if you fail an ability check using a skill or tool with which you have proficiency, you can roll your Psionic Talent die and add the number rolled to the check, potentially turning failure into success.</p>
+		</description>
+		<sheet usage="Psionic Talent">
+			<description>If you fail an ability check using a skill or tool with which you have proficiency, you can roll your Psionic Talent die and add the number rolled to the check, potentially turning failure into success.</description>
 		</sheet>
 	</element>
+	<element name="Psychic Whispers" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_WHISPERS">
+		<compendium display="false" />
+		<description>
+			<p>You can use your psychic abilities to establish telepathic communication between yourself and others—perfect for quiet infiltration. As an action, you give yourself and at least one other creature the ability to speak telepathically with each other. When you do so, roll your Psionic Talent die, and choose creatures you can see, up to a number of creatures equal to the number rolled. For 1 hour, the chosen creatures can speak telepathically with you, and you can speak telepathically with them. To send or receive a message (no action required), you and the other creature must be within 1 mile of each other. A creature can’t use this telepathy if it can’t speak any languages, and a creature can end the telepathic connection at any time (no action required). You and the creature don’t need to speak a common language to understand each other.</p>
+		</description>
+		<sheet action="Action" usage="Psionic Talent">
+			<description>You give yourself and at least one other creature the ability to speak telepathically with each other. When you do so, roll your Psionic Talent die, and choose creatures you can see, up to a number of creatures equal to the number rolled. For 1 hour, the chosen creatures can speak telepathically with you, and you can speak telepathically with them. To send or receive a message, you and the other creature must be within 1 mile of each other. A creature can’t use this telepathy if it can’t speak any languages, and a creature can end the telepathic connection at any time. You and the creature don’t need to speak a common language to understand each other.</description>
+		</sheet>
+	</element>
+	<element name="Psi Replenishment" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_REPLENISHMENT">
+		<compendium display="false" />
+		<description>
+			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="1/Long Rest">
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:soulknife:psionic-talent-die:size}}).</description>
+		</sheet>
+	</element>
+
 	<element name="Psychic Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES">
 		<description>
 			<p><em>3rd-level Soulknife feature</em></p>
@@ -149,7 +284,8 @@
 			<p class="indent">After you attack with the blade, you can make a melee or ranged weapon attack with a second psychic blade as a bonus action on the same turn, provided your other hand is free to create it. The damage die of this bonus attack is 1d4, instead of 1d6.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>When you are about to make a melee or ranged weapon attack against a creature, you can manifest a psychic blade from your free hand and make the attack with that blade. This magic blade is a simple melee weapon with the finesse and thrown properties. It has a normal range of 60 feet and no long range, and on a hit, it deals psychic damage equal to 1d6 plus the ability modifier you used for the attack roll. The blade vanishes immediately after it hits or misses its target, and it leaves no mark on its target if it deals damage.
+			After you attack with the blade, you can make a melee or ranged weapon attack with a second psychic blade as a bonus action on the same turn, provided your other hand is free to create it. The damage die of this bonus attack is 1d4.</description>
 		</sheet>
 	</element>
 	<element name="Soul Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES">
@@ -161,18 +297,40 @@
 				<li><strong>Psychic Teleportation.</strong> If your Psionic Talent die is available, you can hurl your Psychic Blades to magically transport yourself to another location. As a bonus action, you manifest one of your Psychic Blades and throw it at an unoccupied space you can see, up to a number of feet away equal to 5 times the highest number on your Psionic Talent die. You then teleport to that space, the blade vanishes, and your Psionic Talent die decreases by one die size.</li>
 			</ul>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet display="false" />
+		<rules>
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES_HOMING_STRIKES" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES_PSYCHIC_TELEPORTATION" />
+		</rules>
+	</element>
+	<element name="Homing Strikes" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES_HOMING_STRIKES">
+		<compendium display="false" />
+		<description>
+			<p>If you make an attack roll with your Psychic Blades and miss the target, you can roll your Psionic Talent die and add the number rolled to the attack roll. If this causes the attack to hit, your Psionic Talent die decreases by one die size, regardless of the number rolled.</p>
+		</description>
+		<sheet usage="Soul Blades">
+			<description>If you make an attack roll with your Psychic Blades and miss the target, you can roll your Psionic Talent die and add the number rolled to the attack roll. If this causes the attack to hit, your Psionic Talent die decreases by one die size.</description>
 		</sheet>
 	</element>
+	<element name="Psychic Teleportation" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES_PSYCHIC_TELEPORTATION">
+		<compendium display="false" />
+		<description>
+			<p>If your Psionic Talent die is available, you can hurl your Psychic Blades to magically transport yourself to another location. As a bonus action, you manifest one of your Psychic Blades and throw it at an unoccupied space you can see, up to a number of feet away equal to 5 times the highest number on your Psionic Talent die. You then teleport to that space, the blade vanishes, and your Psionic Talent die decreases by one die size.</p>
+		</description>
+		<sheet action="Bonus Action" usage="Soul Blades">
+			<description>If your Psionic Talent die is available, you manifest one of your Psychic Blades and throw it at an unoccupied space you can see, up to a number of feet away equal to 5 times the highest number on your Psionic Talent die. You then teleport to that space, the blade vanishes, and your Psionic Talent die decreases by one die size.</description>
+		</sheet>
+	</element>
+
 	<element name="Psionic Veil" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL">
 		<description>
 			<p><em>13th-level Soulknife feature</em></p>
 			<p>You can weave a veil of psychic static to mask yourself. As an action, you can magically become invisible, along with anything you are wearing or carrying, for 10 minutes or until you dismiss this effect (no action required). This invisibility ends if you deal damage to a creature or if you force a creature to make a saving throw.</p>
 			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet action="Action" usage="1/Long Rest">
+			<description>You can magically become invisible, along with anything you are wearing or carrying, for 10 minutes or until you dismiss this effect. This invisibility ends if you deal damage to a creature or if you force a creature to make a saving throw.
+			Decrease your Psionic Talent die by one die size to use this feature again.</description>
 		</sheet>
 	</element>
 	<element name="Rend Mind" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_REND_MIND">
@@ -182,8 +340,14 @@
 			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>When you use your Psychic Blades to deal Sneak Attack damage to a creature, you can force that target to make a Wisdom save (DC {{ua:rend mind:dc}}). Unless the save succeeds, the target is stunned until the end of your next turn.
+			Decrease your Psionic Talent die by one die size to use this feature again.</description>
 		</sheet>
+		<rules>
+			<stat name="ua:rend mind:dc" value="8" />
+			<stat name="ua:rend mind:dc" value="proficiency" />
+			<stat name="ua:rend mind:dc" value="dexterity:modifier" />
+		</rules>
 	</element>
 
 	<element name="Psionic Soul" type="Archetype" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_SORCERER_PSIONIC_SOUL">
@@ -238,16 +402,65 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>Your Psionic Talent die is a d{{ua:psionic-soul:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
+			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
+		</sheet>
+		<rules>
+			<stat name="ua:psionic-soul:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psionic-soul:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psionic-soul:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psionic-soul:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSI_REPLENISHMENT" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_DISCOVERY" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_SORCERY" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_TELEPATHIC_SPEECH" />
+		</rules>
+	</element>
+	<element name="Psionic Discovery" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_DISCOVERY">
+		<compendium display="false" />
+		<description>
+			<p>You can unlock the ability to cast a mind-oriented sorcerer spell you don’t already know. After meditating for 10 minutes (which can be done during a rest), roll your Psionic Talent die, and choose a sorcerer spell of a level for which you have spell slots and that is in the school of divination or enchantment. You know the chosen spell for a number of hours equal to the number you rolled.</p>
+		</description>
+		<sheet usage="Psionic Talent">
+			<description>After meditating for 10 minutes, roll your Psionic Talent die, and choose a sorcerer spell of a level for which you have spell slots and that is in the school of divination or enchantment. You know the chosen spell for a number of hours equal to the number you rolled.</description>
 		</sheet>
 	</element>
+	<element name="Psychic Sorcery" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_SORCERY">
+		<compendium display="false" />
+		<description>
+			<p>When you cast a spell, you can use your mind to form it, rather than relying on words, gestures, and materials. To do so, roll your Psionic Talent die. The spell then requires no verbal component, and if you rolled the level of the spell or higher, the spell doesn’t require somatic or material components either.</p>
+		</description>
+		<sheet usage="Psionic Talent">
+			<description>When you cast a spell, you can use your mind to form it. To do so, roll your Psionic Talent die. The spell then requires no verbal component, and if you rolled the level of the spell or higher, the spell doesn’t require somatic or material components either.</description>
+		</sheet>
+	</element>
+	<element name="Telepathic Speech" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_TELEPATHIC_SPEECH">
+		<compendium display="false" />
+		<description>
+			<p>You can form a telepathic connection between your mind and the mind of another. As a bonus action, choose one creature you can see, and roll your Psionic Talent die. For a number of hours equal to the number you rolled, you and the chosen creature can speak telepathically with each other while the two of you are within a number of miles of each other equal to the number you rolled. To understand each other, you each must speak mentally in a language the other knows. The telepathic connection ends early if you use this ability to form a connection with a different creature.</p>
+		</description>
+		<sheet action="Bonus Action" usage="Psionic Talent">
+			<description>Choose one creature you can see, and roll your Psionic Talent die. For a number of hours equal to the number you rolled, you and the chosen creature can speak telepathically with each other while the two of you are within a number of miles of each other equal to the number you rolled. To understand each other, you each must speak mentally in a language the other knows. The telepathic connection ends early if you use this ability to form a connection with a different creature.</description>
+		</sheet>
+	</element>
+	<element name="Psi Replenishment" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSI_REPLENISHMENT">
+		<compendium display="false" />
+		<description>
+			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
+		</description>
+		<sheet action="Bonus Action" usage="1/Long Rest">
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-soul:psionic-talent-die:size}}).</description>
+		</sheet>
+	</element>
+
 	<element name="Psychic Strike" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE">
 		<description>
 			<p><em>6th-level Psionic Soul feature</em></p>
 			<p>You have learned to channel additional psychic energy into your spells. Immediately after you deal damage to a creature with a sorcerer spell for which you expend a spell slot, you can roll your Psionic Talent die and also deal psychic damage to that creature equal to the number rolled. You can deal this extra damage only once per turn.</p>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet usage="1/Turn">
+			<description>Immediately after you deal damage to a creature with a sorcerer spell for which you expend a spell slot, you can roll your Psionic Talent die and also deal psychic damage to that creature equal to the number rolled.</description>
 		</sheet>
 	</element>
 	<element name="Mind Over Body" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_MIND_OVER_BODY">
@@ -261,18 +474,27 @@
 				<li>Your body, along with any equipment you are wearing or carrying, becomes pliable. You can move through any space as narrow as 1 inch without squeezing, and you can spend 5 feet of movement to escape from nonmagical restraints or being grappled.</li>
 			</ul>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet action="Bonus Action">
+			<description>You can roll your Psionic Talent die and spend 1 or more sorcery points to magically transform yourself for a number of hours equal to the number rolled. Until the transformation ends, you gain one of the following benefits of your choice for each sorcery point you spent, choosing a different benefit for each point:
+			You can see any invisible creature within 60 feet of you, provided it isn’t behind total cover.
+			You gain a {{speed}}ft. flying speed, and you can hover.
+			You gain a {{mind over body:swimming speed}}ft swimming speed, and you can breathe underwater.
+			Your body, along with any equipment you are wearing or carrying, becomes pliable. You can move through any space as narrow as 1 inch without squeezing, and you can spend 5 feet of movement to escape from nonmagical restraints or being grappled.</description>
 		</sheet>
+		<rules>
+			<stat name="mind over body:swimming speed" value="speed" />
+			<stat name="mind over body:swimming speed" value="speed" />
+		</rules>
 	</element>
 	<element name="Psychic Aura" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_AURA">
 		<description>
 			<p><em>18th-level Psionic Soul feature</em></p>
-			<p>If your Psionic Talent die is available, you can unleash your psionic power in a crackling aura of psychic energy; as a bonus action, you can magically radiate this transparent, 30-footradius aura for 1 minute or until you’re incapacitated or lose the use of your Psionic Talent die.</p>
+			<p>If your Psionic Talent die is available, you can unleash your psionic power in a crackling aura of psychic energy; as a bonus action, you can magically radiate this transparent, 30-foot radius aura for 1 minute or until you’re incapacitated or lose the use of your Psionic Talent die.</p>
 			<p class="indent">Whenever a creature starts its turn in the aura or moves into it for the first time on a turn, you can roll your Psionic Talent die and deal psychic damage to the creature, equaling the number rolled plus your Charisma modifier. If the creature takes any of this damage, its speed is halved until the start of its next turn.</p>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet action="Bonus Action">
+			<description>If your Psionic Talent die is available, you can magically radiate this transparent, 30-foot radius aura for 1 minute or until you’re incapacitated or lose the use of your Psionic Talent die.
+			Whenever a creature starts its turn in the aura or moves into it for the first time on a turn, you can roll your Psionic Talent die and deal psychic damage to the creature, equaling the number rolled plus {{charisma:modifier}}. If the creature takes any of this damage, its speed is halved until the start of its next turn.</description>
 		</sheet>
 	</element>
 
@@ -353,8 +575,12 @@
 			</ul>
 		</description>
 		<sheet>
-			<description></description>
+			<description>If your Psionic Talent die is available, you can take an action to channel your psionic power to nourish yourself for the next 24 hours, as if you consumed sufficient food and water for a day. When you take this action, your Psionic Talent die decreases by one die size.
+			If your Psionic Talent die is available, you can meditate for 1 minute, at the end of which you gain the benefits of finishing a short rest, and your Psionic Talent die decreases by one die size. You can’t meditate in this way again until you finish a long rest.</description>
 		</sheet>
+		<rules>
+			<select type="Ability Score Improvement" name="Ability Score Increase, Metabolic Control" supports="ID_PHB_FEAT_ASI_STRENGTH|ID_PHB_FEAT_ASI_DEXTERITY|ID_PHB_FEAT_ASI_CONSTITUTION" />
+		</rules>
 	</element>
 	<element name="Telekinetic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEKINETIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
@@ -369,9 +595,69 @@
 			</ul>
 		</description>
 		<sheet>
+			<description>You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is {{ua:telekinetic:ability}}.
+			As a bonus action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, roll your Psionic Talent die, and the target must succeed on a DC {{ua:telekinetic:shove dc}} Strength save or be moved toward you or away from you a number of feet equal to 5 times the number you rolled. A creature can willingly fail this save.</description>
+		</sheet>
+		<rules>
+			<!-- <select type="Ability Score Improvement" name="Ability Score Increase, Telekinetic" supports="ID_PHB_FEAT_ASI_INTELLIGENCE|ID_PHB_FEAT_ASI_WISDOM|ID_PHB_FEAT_ASI_CHARISMA" /> -->
+			<grant type="Spell" id="ID_PHB_SPELL_MAGE_HAND" />
+			<stat name="ua:telekinetic:shove dc" value="8" />
+			<stat name="ua:telekinetic:shove dc" value="proficiency" />
+			<select type="Feat Feature" name="Ability Score Increase, Telekinetic" supports="ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_INTELLIGENCE|ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_WISDOM|ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_CHARISMA" />
+		</rules>
+	</element>
+	<element name="Intelligence" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_INTELLIGENCE">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Intelligence by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEKINETIC" />
+			</div>
+		</description>
+		<sheet display="false">
 			<description></description>
 		</sheet>
+		<rules>
+			<stat name="intelligence" value="1" alt="Telekinetic" />
+			<stat name="ua:telekinetic:ability" value="Intelligence" inline="true"/>
+			<stat name="ua:telekinetic:shove dc" value="intelligence:modifier" />
+		</rules>
 	</element>
+	<element name="Wisdom" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_WISDOM">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Wisdom by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEKINETIC" />
+			</div>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<stat name="wisdom" value="1" alt="Telekinetic" />
+			<stat name="ua:telekinetic:ability" value="Wisdom" inline="true"/>	
+			<stat name="ua:telekinetic:shove dc" value="wisdom:modifier" />
+		</rules>
+	</element>
+	<element name="Charisma" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEKINETIC_CHARISMA">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Charisma by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEKINETIC" />
+			</div>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<stat name="charisma" value="1" alt="Telekinetic" />
+			<stat name="ua:telekinetic:ability" value="Charisma" inline="true"/>	
+			<stat name="ua:telekinetic:shove dc" value="charisma:modifier" />
+		</rules>
+	</element>
+
 	<element name="Telepathic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEPATHIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
 		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
@@ -385,9 +671,62 @@
 			</ul>
 		</description>
 		<sheet>
+			<description>You can speak telepathically to any creature you can see within 30 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn’t give the creature the ability to respond to you telepathically.
+			If your Psionic Talent die is available, you can cast the detect thoughts spell, requiring no components. When you start casting the spell, your Psionic Talent die decreases by one die size. Your spellcasting ability for the spell is {{ua:telepathic:spellcasting ability}}.</description>
+		</sheet>
+		<rules>
+			<select type="Feat Feature" name="Ability Score Increase, Telepathic" supports="ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_INTELLIGENCE|ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_WISDOM|ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_CHARISMA" />
+		</rules>
+	</element>
+	<element name="Intelligence" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_INTELLIGENCE">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Intelligence by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEPATHIC" />
+			</div>
+		</description>
+		<sheet display="false">
 			<description></description>
 		</sheet>
+		<rules>
+			<stat name="intelligence" value="1" alt="Telepathic" />
+			<stat name="ua:telepathic:spellcasting ability" value="Intelligence" inline="true"/>
+		</rules>
 	</element>
+	<element name="Wisdom" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_WISDOM">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Wisdom by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEPATHIC" />
+			</div>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<stat name="wisdom" value="1" alt="Telepathic" />
+			<stat name="ua:telepathic:spellcasting ability" value="Wisdom" inline="true"/>	
+		</rules>
+	</element>
+	<element name="Charisma" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_TELEPATHIC_CHARISMA">
+		<compendium display="false" />
+		<description>
+			<p>Increase your Charisma by 1, to a maximum of 20.</p>
+			<div class="reference">
+				<div element="ID_WOTC_UA20200414_FEAT_TELEPATHIC" />
+			</div>
+		</description>
+		<sheet display="false">
+			<description></description>
+		</sheet>
+		<rules>
+			<stat name="charisma" value="1" alt="Telepathic" />
+			<stat name="ua:telepathic:spellcasting ability" value="Charisma" inline="true"/>	
+		</rules>
+	</element>
+	
 	<element name="Tower of Iron Will" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TOWER_OF_IRON_WILL">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
 		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
@@ -395,10 +734,11 @@
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
 			<p>Your mind’s defenses are formidable. After you or another creature you can see within 30 feet of you fails a saving throw, you can use your reaction to roll your Psionic Talent die and add the number rolled to the saving throw, potentially causing it to succeed.</p>
 		</description>
-		<sheet>
-			<description></description>
+		<sheet action="Reaction">
+			<description>After you or another creature you can see within 30 feet of you fails a saving throw, you can roll your Psionic Talent die and add the number rolled to the saving throw, potentially causing it to succeed.</description>
 		</sheet>
 	</element>
+
 	<element name="Wild Talent" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_WILD_TALENT">
 		<description>
 			<p>You awaken to your psionic potential, which enhances your mind or body. Increase one ability score of your choice by 1, to a maximum of 20, to represent this enhancement.</p>
@@ -413,8 +753,50 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description></description>
+			<description>Your Psionic Talent die is a d{{ua:wild-talent:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
+			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
+		</sheet>
+		<rules>
+			<select type="Ability Score Improvement" name="Ability Score Increase, Wild Talent" supports="Feat" />
+			<stat name="ua:wild-talent:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:wild-talent:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:wild-talent:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:wild-talent:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_BOOSTED_ABILITY" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_GUIDED_STRIKE" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_REPLENISHMENT" />
+		</rules>
+	</element>
+
+	<element name="Psi-Boosted Ability" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_BOOSTED_ABILITY">
+		<compendium display="false" />
+		<description>
+			<p>When you make an ability check with the ability increased by this feat, you can roll your Psionic Talent die and add the number rolled to the check. You can choose to do so before or after rolling the d20, but before you know whether the check succeeded or failed.</p>
+		</description>
+		<sheet usage="Wild Talent">
+			<description>When you make an ability check with the ability increased by this feat, you can roll your Psionic Talent die and add the number rolled to the check. You can choose to do so before or after rolling the d20, but before you know whether the check succeeded or failed.</description>
 		</sheet>
 	</element>
+	<element name="Psi-Guided Strike" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_GUIDED_STRIKE">
+		<compendium display="false" />
+		<description>
+			<p>Once on each of your turns when you hit with an attack roll that uses the ability increased by this feat, you can roll your Psionic Talent die after you make the damage roll and then replace one of the damage dice with the number rolled on the Psionic Talent die.</p>
+		</description>
+		<sheet usage="Wild Talent">
+			<description>Once on each of your turns when you hit with an attack roll that uses the ability increased by this feat, you can roll your Psionic Talent die after you make the damage roll and then replace one of the damage dice with the number rolled on the Psionic Talent die.</description>
+		</sheet>
+	</element>
+	<element name="Psi Replenishment" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_REPLENISHMENT">
+		<compendium display="false" />
+		<description>
+			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
+		</description>
+		<sheet usage="1/Long Rest">
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:wild-talent:psionic-talent-die:size}}).</description>
+		</sheet>
+	</element>
+
+	<!-- todo: use generic grant for psionic talent if published in this form -->
 
 </elements>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -120,7 +120,6 @@
 			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
-
 	<element name="Telekinetic Adept" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT">
 		<description>
 			<p><em>7th-level Psi Knight feature</em></p>
@@ -157,7 +156,6 @@
 			<description>If your Psionic Talent die is available, you can move an object or a creature with your mind. You target one loose object that is Large or smaller or one willing creature, other than yourself. If you can see the target and it is within 30 feet of you, you can move it up to 30 feet to an unoccupied space you can see. Alternatively, if it is a Tiny object, you can move it to or from your hand. Either way, you can move the target horizontally, vertically, or both. When you take this action, your Psionic Talent die decreases by one die size.</description>
 		</sheet>
 	</element>
-
 	<element name="Psi-Enhanced Metabolism" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM">
 		<description>
 			<p><em>10th-level Psi Knight feature</em></p>
@@ -278,7 +276,6 @@
 			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
-
 	<element name="Psychic Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES">
 		<description>
 			<p><em>3rd-level Soulknife feature</em></p>
@@ -323,7 +320,6 @@
 			<description>If your Psionic Talent die is available, you manifest one of your Psychic Blades and throw it at an unoccupied space you can see, up to a number of feet away equal to 5 times the highest number on your Psionic Talent die. You then teleport to that space, the blade vanishes, and your Psionic Talent die decreases by one die size.</description>
 		</sheet>
 	</element>
-
 	<element name="Psionic Veil" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL">
 		<description>
 			<p><em>13th-level Soulknife feature</em></p>
@@ -456,7 +452,6 @@
 			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
-
 	<element name="Psychic Strike" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE">
 		<description>
 			<p><em>6th-level Psionic Soul feature</em></p>
@@ -567,7 +562,7 @@
 
 	<element name="Metabolic Control" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_METABOLIC_CONTROL">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
+		<requirements>ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
 			<p>You have refined psionic control over your body’s functions. You gain the following benefits:</p>
@@ -587,7 +582,7 @@
 	</element>
 	<element name="Telekinetic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEKINETIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
+		<requirements>ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
 			<p>You learn to move things with your mind. You gain the following benefits:</p>
@@ -660,10 +655,9 @@
 			<stat name="ua:telekinetic:shove dc" value="charisma:modifier" />
 		</rules>
 	</element>
-
 	<element name="Telepathic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEPATHIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
+		<requirements>ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
 			<p>You awaken the ability to mentally connect with others. You gain the following benefits:</p>
@@ -728,11 +722,10 @@
 			<stat name="charisma" value="1" alt="Telepathic" />
 			<stat name="ua:telepathic:spellcasting ability" value="Charisma" inline="true"/>	
 		</rules>
-	</element>
-	
+	</element>	
 	<element name="Tower of Iron Will" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TOWER_OF_IRON_WILL">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
+		<requirements>ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
 			<p>Your mind’s defenses are formidable. After you or another creature you can see within 30 feet of you fails a saving throw, you can use your reaction to roll your Psionic Talent die and add the number rolled to the saving throw, potentially causing it to succeed.</p>
@@ -741,7 +734,6 @@
 			<description>After you or another creature you can see within 30 feet of you fails a saving throw, you can roll your Psionic Talent die and add the number rolled to the saving throw, potentially causing it to succeed.</description>
 		</sheet>
 	</element>
-
 	<element name="Wild Talent" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_WILD_TALENT">
 		<description>
 			<p>You awaken to your psionic potential, which enhances your mind or body. Increase one ability score of your choice by 1, to a maximum of 20, to represent this enhancement.</p>
@@ -771,7 +763,6 @@
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_REPLENISHMENT" requirements="!ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
 		</rules>
 	</element>
-
 	<element name="Psi-Boosted Ability" type="Feat Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_BOOSTED_ABILITY">
 		<compendium display="false" />
 		<description>
@@ -800,7 +791,7 @@
 		</sheet>
 	</element>
 
+	<!-- todo: replace with official if ever published in this form -->
 	<element name="Psionic Talent feature" type="Grants" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
-
 
 </elements>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -43,7 +43,18 @@
 	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT">
 		<description>
 			<p><em>3rd-level Psi Knight feature</em></p>
-			<p></p>
+			<p>You harbor a wellspring of psionic power within yourself, an energy that ebbs and flows as you channel it in various ways. This power is represented by your Psionic Talent die, the starting size of which is a d6.</p>
+			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>
+			<ul class="unstyled mb">
+				<li><strong>Protective Field.</strong> When you or another creature you can see within 30 feet of you takes damage, you can use your reaction to roll your Psionic Talent die and reduce the damage taken by the number rolled plus your Intelligence modifier (minimum reduction of 1), as you create a momentary shield of telekinetic force.</li>
+				<li><strong>Psi-Powered Leap.</strong> When you make a high or long jump, you can roll your Psionic Talent die and extend the distance of the jump, up to a number of feet equal to twice the number rolled plus twice your Intelligence modifier (minimum of 1 extra foot). This extra distance costs you only 1 foot of movement.</li>
+				<li><strong>Telekinetic Strike.</strong> You can propel your attacks with telekinetic force. Once on each of your turns, immediately after you deal damage to a target within 30 feet of you with a weapon attack, you can roll your Psionic Talent die and also deal force damage to the target equal to the number rolled.</li>
+			</ul>
+			<br />
+			<p class="indent"><strong><em>Changing the Die’s Size.</em></strong> If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. This represents you burning through your psionic energy. For example, if the die is a d6 and you roll a 6, it becomes a d4. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.</p>
+			<p class="indent">Conversely, if you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size. This represents you conserving psionic energy for later use. For example, if you roll a 1 on a d4, the die then becomes a d6.</p>
+			<p class="indent">Whenever you finish a long rest, your Psionic Talent die resets to its starting size. When you reach certain levels in this class, the starting size of your Psionic Talent die increases: at 5th level (d8), 11th level (d10), and 17th level (d12).</p>
+			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -52,7 +63,11 @@
 	<element name="Telekinetic Adept" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_ADEPT">
 		<description>
 			<p><em>7th-level Psi Knight feature</em></p>
-			<p></p>
+			<p>You have mastered new ways to use your telekinesis:</p>
+			<ul class="unstyled">
+				<li><strong>Psionic Thrust.</strong> When you deal damage to a target with the Telekinetic Strike of your Psionic Talent, you can force the target to make a Strength saving throw against a DC equal to 8 + your proficiency bonus + your Intelligence modifier. Unless the save succeeds, you can knock the target prone or move it up to 10 feet in any direction horizontally.</li>
+				<li><strong>Telekinetic Movement.</strong> If your Psionic Talent die is available, you can move an object or a creature with your mind. As an action, you target one loose object that is Large or smaller or one willing creature, other than yourself. If you can see the target and it is within 30 feet of you, you can move it up to 30 feet to an unoccupied space you can see. Alternatively, if it is a Tiny object, you can move it to or from your hand. Either way, you can move the target horizontally, vertically, or both. When you take this action, your Psionic Talent die decreases by one die size.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -61,7 +76,7 @@
 	<element name="Psi-Enhanced Metabolism" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_ENHANCED_METABOLISM">
 		<description>
 			<p><em>10th-level Psi Knight feature</em></p>
-			<p></p>
+			<p>The psionic energy flowing through you has bolstered your mind and body. You have resistance to poison and psychic damage, and you are immune to the poisoned condition.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -70,7 +85,8 @@
 	<element name="Bulwark of Force" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_BULWARK_OF_FORCE">
 		<description>
 			<p><em>15th-level Psi Knight feature</em></p>
-			<p></p>
+			<p>You can shield yourself and others with telekinetic force. As a bonus action, you can choose creatures, which can include you, that you can see within 30 feet of you, up to a number of creatures equal to your Intelligence modifier (minimum of one creature). Each of the chosen creatures is protected by half cover for 1 minute or until you’re incapacitated.</p>
+			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -79,7 +95,7 @@
 	<element name="Telekinetic Master" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_TELEKINETIC_MASTER">
 		<description>
 			<p><em>18th-level Psi Knight feature</em></p>
-			<p></p>
+			<p>Your ability to move creatures and objects with your mind is matched by few. If your Psionic Talent die is available, you can cast the telekinesis spell, requiring no components. Your spellcasting ability for the spell is Intelligence. When you cast this spell, your Psionic Talent die decreases by one die size.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -110,7 +126,17 @@
 	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT">
 		<description>
 			<p><em>3rd-level Soulknife feature</em></p>
-			<p></p>
+			<p>You harbor a wellspring of psionic power within yourself, an energy that ebbs and flows as you channel it in various ways. This power is represented by your Psionic Talent die, the starting size of which is a d6.</p>
+			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>
+			<ul class="unstyled mb">
+				<li><strong>Psi-Bolstered Knack.</strong> When your non-psionic training fails you, you can tap into your psionic power to help: if you fail an ability check using a skill or tool with which you have proficiency, you can roll your Psionic Talent die and add the number rolled to the check, potentially turning failure into success.</li>
+				<li><strong>Psychic Whispers.</strong> You can use your psychic abilities to establish telepathic communication between yourself and others—perfect for quiet infiltration. As an action, you give yourself and at least one other creature the ability to speak telepathically with each other. When you do so, roll your Psionic Talent die, and choose creatures you can see, up to a number of creatures equal to the number rolled. For 1 hour, the chosen creatures can speak telepathically with you, and you can speak telepathically with them. To send or receive a message (no action required), you and the other creature must be within 1 mile of each other. A creature can’t use this telepathy if it can’t speak any languages, and a creature can end the telepathic connection at any time (no action required). You and the creature don’t need to speak a common language to understand each other.</li>
+			</ul>
+			<br />
+			<p class="indent"><strong><em>Changing the Die’s Size.</em></strong> If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. This represents you burning through your psionic energy. For example, if the die is a d6 and you roll a 6, it becomes a d4. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.</p>
+			<p class="indent">Conversely, if you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size. This represents you conserving psionic energy for later use. For example, if you roll a 1 on a d4, the die then becomes a d6.</p>
+			<p class="indent">Whenever you finish a long rest, your Psionic Talent die resets to its starting size. When you reach certain levels in this class, the starting size of your Psionic Talent die increases: at 5th level (d8), 11th level (d10), and 17th level (d12).</p>
+			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -119,7 +145,8 @@
 	<element name="Psychic Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_BLADES">
 		<description>
 			<p><em>3rd-level Soulknife feature</em></p>
-			<p></p>
+			<p>You can manifest your psionic power as shimmering blades of psychic energy. When you are about to make a melee or ranged weapon attack against a creature, you can manifest a psychic blade from your free hand and make the attack with that blade. This magic blade is a simple melee weapon with the finesse and thrown properties. It has a normal range of 60 feet and no long range, and on a hit, it deals psychic damage equal to 1d6 plus the ability modifier you used for the attack roll. The blade vanishes immediately after it hits or misses its target, and it leaves no mark on its target if it deals damage.</p>
+			<p class="indent">After you attack with the blade, you can make a melee or ranged weapon attack with a second psychic blade as a bonus action on the same turn, provided your other hand is free to create it. The damage die of this bonus attack is 1d4, instead of 1d6.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -128,7 +155,11 @@
 	<element name="Soul Blades" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_SOUL_BLADES">
 		<description>
 			<p><em>9th-level Soulknife feature</em></p>
-			<p></p>
+			<p>Your Psychic Blades are now an expression of your psi-suffused soul, giving you finer control over them in the following ways:</p>
+			<ul class="unstyled">
+				<li><strong>Homing Strikes.</strong> If you make an attack roll with your Psychic Blades and miss the target, you can roll your Psionic Talent die and add the number rolled to the attack roll. If this causes the attack to hit, your Psionic Talent die decreases by one die size, regardless of the number rolled.</li>
+				<li><strong>Psychic Teleportation.</strong> If your Psionic Talent die is available, you can hurl your Psychic Blades to magically transport yourself to another location. As a bonus action, you manifest one of your Psychic Blades and throw it at an unoccupied space you can see, up to a number of feet away equal to 5 times the highest number on your Psionic Talent die. You then teleport to that space, the blade vanishes, and your Psionic Talent die decreases by one die size.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -137,7 +168,8 @@
 	<element name="Psionic Veil" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_VEIL">
 		<description>
 			<p><em>13th-level Soulknife feature</em></p>
-			<p></p>
+			<p>You can weave a veil of psychic static to mask yourself. As an action, you can magically become invisible, along with anything you are wearing or carrying, for 10 minutes or until you dismiss this effect (no action required). This invisibility ends if you deal damage to a creature or if you force a creature to make a saving throw.</p>
+			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -146,7 +178,8 @@
 	<element name="Rend Mind" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_REND_MIND">
 		<description>
 			<p><em>17th-level Soulknife feature</em></p>
-			<p></p>
+			<p>You can sweep your Psychic Blades directly through a creature’s mind. When you use your Psychic Blades to deal Sneak Attack damage to a creature, you can force that target to make a Wisdom saving throw (DC equal to 8 + your proficiency bonus + your Dexterity modifier). Unless the save succeeds, the target is stunned until the end of your next turn.</p>
+			<p class="indent">Once you use this feature, you can’t do so again until you finish a long rest, unless you decrease your Psionic Talent die by one die size to use this feature again.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -191,7 +224,18 @@
 	<element name="Psionic Talent" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT">
 		<description>
 			<p><em>1st-level Psionic Soul feature</em></p>
-			<p></p>
+			<p>You harbor a wellspring of psionic power within yourself, an energy that ebbs and flows as you channel it in various ways. This power is represented by your Psionic Talent die, the starting size of which is a d6.</p>
+			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>
+			<ul class="unstyled mb">
+				<li><strong>Psionic Discovery.</strong> You can unlock the ability to cast a mind-oriented sorcerer spell you don’t already know. After meditating for 10 minutes (which can be done during a rest), roll your Psionic Talent die, and choose a sorcerer spell of a level for which you have spell slots and that is in the school of divination or enchantment. You know the chosen spell for a number of hours equal to the number you rolled.</li>
+				<li><strong>Psychic Sorcery.</strong> When you cast a spell, you can use your mind to form it, rather than relying on words, gestures, and materials. To do so, roll your Psionic Talent die. The spell then requires no verbal component, and if you rolled the level of the spell or higher, the spell doesn’t require somatic or material components either.</li>
+				<li><strong>Telepathic Speech.</strong> You can form a telepathic connection between your mind and the mind of another. As a bonus action, choose one creature you can see, and roll your Psionic Talent die. For a number of hours equal to the number you rolled, you and the chosen creature can speak telepathically with each other while the two of you are within a number of miles of each other equal to the number you rolled. To understand each other, you each must speak mentally in a language the other knows. The telepathic connection ends early if you use this ability to form a connection with a different creature.</li>
+			</ul>
+			<br />
+			<p class="indent"><strong><em>Changing the Die’s Size.</em></strong> If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. This represents you burning through your psionic energy. For example, if the die is a d6 and you roll a 6, it becomes a d4. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.</p>
+			<p class="indent">Conversely, if you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size. This represents you conserving psionic energy for later use. For example, if you roll a 1 on a d4, the die then becomes a d6.</p>
+			<p class="indent">Whenever you finish a long rest, your Psionic Talent die resets to its starting size. When you reach certain levels in this class, the starting size of your Psionic Talent die increases: at 5th level (d8), 11th level (d10), and 17th level (d12).</p>
+			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -200,7 +244,7 @@
 	<element name="Psychic Strike" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_STRIKE">
 		<description>
 			<p><em>6th-level Psionic Soul feature</em></p>
-			<p></p>
+			<p>You have learned to channel additional psychic energy into your spells. Immediately after you deal damage to a creature with a sorcerer spell for which you expend a spell slot, you can roll your Psionic Talent die and also deal psychic damage to that creature equal to the number rolled. You can deal this extra damage only once per turn.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -209,7 +253,13 @@
 	<element name="Mind Over Body" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_MIND_OVER_BODY">
 		<description>
 			<p><em>14th-level Psionic Soul feature</em></p>
-			<p></p>
+			<p>You can now use the psi that flows through you to give your body extraordinary abilities. As a bonus action, you can roll your Psionic Talent die and spend 1 or more sorcery points to magically transform yourself for a number of hours equal to the number rolled. Until the transformation ends, you gain one of the following benefits of your choice for each sorcery point you spent, choosing a different benefit for each point:</p>
+			<ul>
+				<li>You can see any invisible creature within 60 feet of you, provided it isn’t behind total cover.</li>
+				<li>You gain a flying speed equal to your walking speed, and you can hover.</li>
+				<li>You gain a swimming speed equal to twice your walking speed, and you can breathe underwater.</li>
+				<li>Your body, along with any equipment you are wearing or carrying, becomes pliable. You can move through any space as narrow as 1 inch without squeezing, and you can spend 5 feet of movement to escape from nonmagical restraints or being grappled.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -218,7 +268,8 @@
 	<element name="Psychic Aura" type="Archetype Feature" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_AURA">
 		<description>
 			<p><em>18th-level Psionic Soul feature</em></p>
-			<p></p>
+			<p>If your Psionic Talent die is available, you can unleash your psionic power in a crackling aura of psychic energy; as a bonus action, you can magically radiate this transparent, 30-footradius aura for 1 minute or until you’re incapacitated or lose the use of your Psionic Talent die.</p>
+			<p class="indent">Whenever a creature starts its turn in the aura or moves into it for the first time on a turn, you can roll your Psionic Talent die and deal psychic damage to the creature, equaling the number rolled plus your Charisma modifier. If the creature takes any of this damage, its speed is halved until the start of its next turn.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -226,72 +277,80 @@
 	</element>
 
 	<element name="Intellect Fortress" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_INTELLECT_FORTRESS">
-		<supports>supports</supports>
+		<supports>Bard,Sorcerer,Wizard</supports>
 		<description>
-			<p></p>
+			<p>For the duration, you or one willing creature you can see within range has resistance to psychic damage, as well as advantage on Intelligence, Wisdom, and Charisma saving throws.</p>
+			<p class="indent"><strong><em>At Higher Levels.</em></strong> When you cast this spell using a spell slot of 5th level or higher, you can target one additional creature for each slot level above 4th. The creatures must be within 30 feet of each other when you target them.</p>
 		</description>
 		<setters>
-			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Evocation</set>
-			<set name="time">time</set>
-			<set name="range">range</set>
-			<set name="duration">duration</set>
+			<set name="keywords">psychic</set>
+			<set name="level">4</set>
+			<set name="school">Abjuration</set>
+			<set name="time">1 action</set>
+			<set name="range">30 feet</set>
+			<set name="duration">Concentration, up to 1 hour</set>
 			<set name="hasVerbalComponent">true</set>
-			<set name="hasSomaticComponent">true</set>
-			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
-			<set name="isConcentration">false</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent"></set>
+			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Mind Sliver" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_MIND_SLIVER">
-		<supports>supports</supports>
+		<supports>Sorcerer,Warlock,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You drive a disorienting spike of psychic energy into the mind of one creature you can see within range. The target must make an Intelligence saving throw. Unless the saving throw is successful, the target takes 1d6 psychic damage, and the first time it makes a saving throw before the end of your next turn, it must roll a d4 and subtract the number rolled from the save.</p>
+			<p class="indent">This spell’s damage increases by 1d6 when you reach certain levels: 5th level (2d6), 11th level (3d6), and 17th level (4d6).</p>
 		</description>
 		<setters>
-			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Evocation</set>
-			<set name="time">time</set>
-			<set name="range">range</set>
-			<set name="duration">duration</set>
+			<set name="keywords">psychic</set>
+			<set name="level">0</set>
+			<set name="school">Enchantment</set>
+			<set name="time">1 action</set>
+			<set name="range">60 feet</set>
+			<set name="duration">1 round</set>
 			<set name="hasVerbalComponent">true</set>
-			<set name="hasSomaticComponent">true</set>
-			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
-			<set name="isConcentration">false</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent"></set>
+			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 	<element name="Mind Thrust" type="Spell" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_SPELL_MIND_THRUST">
-		<supports>supports</supports>
+		<supports>Sorcerer,Wizard</supports>
 		<description>
-			<p></p>
+			<p>You thrust a lance of psychic disruption into the mind of one creature you can see within range. The target must make an Intelligence saving throw. On a failed save, the target takes 3d6 psychic damage, and it can’t take a reaction until the end of its next turn. Moreover, on its next turn, it must choose whether it gets a move, an action, or a bonus action; it gets only one of the three. On a successful save, the target takes half as much damage and suffers none of the spell’s other effects.</p>
+			<p class="indent">When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd. The creatures must be within 30 feet of each other when you target them.</p>
 		</description>
 		<setters>
-			<set name="keywords"></set>
-			<set name="level">level</set>
-			<set name="school">Evocation</set>
-			<set name="time">time</set>
-			<set name="range">range</set>
-			<set name="duration">duration</set>
+			<set name="keywords">psychic</set>
+			<set name="level">2</set>
+			<set name="school">enchantment</set>
+			<set name="time">1 action</set>
+			<set name="range">90 feet</set>
+			<set name="duration">1 round</set>
 			<set name="hasVerbalComponent">true</set>
-			<set name="hasSomaticComponent">true</set>
-			<set name="hasMaterialComponent">true</set>
-			<set name="materialComponent">component</set>
-			<set name="isConcentration">false</set>
+			<set name="hasSomaticComponent">false</set>
+			<set name="hasMaterialComponent">false</set>
+			<set name="materialComponent"></set>
+			<set name="isConcentration">true</set>
 			<set name="isRitual">false</set>
 		</setters>
 	</element>
 
 	<element name="Metabolic Control" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_METABOLIC_CONTROL">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements></requirements>
+		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
-			<p></p>
+			<p>You have refined psionic control over your body’s functions. You gain the following benefits:</p>
+			<ul>
+				<li>Increase your Strength, Dexterity, or Constitution score by 1, to a maximum of 20.</li>
+				<li>If your Psionic Talent die is available, you can take an action to channel your psionic power to nourish yourself for the next 24 hours, as if you consumed sufficient food and water for a day. When you take this action, your Psionic Talent die decreases by one die size.</li>
+				<li>If your Psionic Talent die is available, you can meditate for 1 minute, at the end of which you gain the benefits of finishing a short rest, and your Psionic Talent die decreases by one die size. You can’t meditate in this way again until you finish a long rest.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -299,10 +358,15 @@
 	</element>
 	<element name="Telekinetic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEKINETIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements></requirements>
+		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
-			<p></p>
+			<p>You learn to move things with your mind. You gain the following benefits:</p>
+			<ul>
+				<li>Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.</li>
+				<li>You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is the ability increased by this feat.</li>
+				<li>As a bonus action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, roll your Psionic Talent die, and the target must succeed on a Strength saving throw (DC 8 + your proficiency bonus + the ability modifier of the score increased by this feat) or be moved toward you or away from you a number of feet equal to 5 times the number you rolled. A creature can willingly fail this save.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -310,10 +374,15 @@
 	</element>
 	<element name="Telepathic" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TELEPATHIC">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements></requirements>
+		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
-			<p></p>
+			<p>You awaken the ability to mentally connect with others. You gain the following benefits:</p>
+			<ul>
+				<li>Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.</li>
+				<li>You can speak telepathically to any creature you can see within 30 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn’t give the creature the ability to respond to you telepathically.</li>
+				<li>If your Psionic Talent die is available, you can cast the detect thoughts spell, requiring no components. When you start casting the spell, your Psionic Talent die decreases by one die size. Your spellcasting ability for the spell is the ability increased by this feat.</li>
+			</ul>
 		</description>
 		<sheet>
 			<description></description>
@@ -321,10 +390,10 @@
 	</element>
 	<element name="Tower of Iron Will" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_TOWER_OF_IRON_WILL">
 		<prerequisite>Psionic Talent feature or Wild Talent feat</prerequisite>
-		<requirements></requirements>
+		<requirements>ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSIONIC_TALENT||ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_TALENT||ID_WOTC_UA20200414_FEAT_WILD_TALENT</requirements>
 		<description>
 			<p><em>Prerequisite: Psionic Talent feature or Wild Talent feat</em></p>
-			<p></p>
+			<p>Your mind’s defenses are formidable. After you or another creature you can see within 30 feet of you fails a saving throw, you can use your reaction to roll your Psionic Talent die and add the number rolled to the saving throw, potentially causing it to succeed.</p>
 		</description>
 		<sheet>
 			<description></description>
@@ -332,7 +401,16 @@
 	</element>
 	<element name="Wild Talent" type="Feat" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_FEAT_WILD_TALENT">
 		<description>
-			<p></p>
+			<p>You awaken to your psionic potential, which enhances your mind or body. Increase one ability score of your choice by 1, to a maximum of 20, to represent this enhancement.</p>
+			<p class="indent">You also harbor a wellspring of psionic power within yourself, an energy that ebbs and flows as you channel it in various ways. This power is represented by your Psionic Talent die, the starting size of which is a d6.</p>
+			<p class="indent"><strong><em>Psionic Talent Options.</em></strong> You can use your Psionic Talent die in the following ways:</p>			
+			<p class=""><strong>Psi-Boosted Ability.</strong> When you make an ability check with the ability increased by this feat, you can roll your Psionic Talent die and add the number rolled to the check. You can choose to do so before or after rolling the d20, but before you know whether the check succeeded or failed.</p>
+			<p class=""><strong>Psi-Guided Strike.</strong> Once on each of your turns when you hit with an attack roll that uses the ability increased by this feat, you can roll your Psionic Talent die after you make the damage roll and then replace one of the damage dice with the number rolled on the Psionic Talent die.</p>
+			<p class="indent"><strong><em>Changing the Die’s Size.</em></strong> If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. This represents you burning through your psionic energy. For example, if the die is a d6 and you roll a 6, it becomes a d4. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.</p>
+			<p class="indent">Conversely, if you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size. This represents you conserving psionic energy for later use. For example, if you roll a 1 on a d4, the die then becomes a d6.</p>
+			<p class="indent">Whenever you finish a long rest, your Psionic Talent die resets to its starting size. When you reach certain levels, the starting size of your Psionic Talent die increases: at 5th level (d8), 11th level (d10), and 17th level (d12).</p>
+			<p class="indent">If you have a Psionic Talent die from another source, such as a class feature, you don’t get more than one die; use only the one with the largest starting size.</p>
+			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
 			<description></description>

--- a/unearthed-arcana/2020/20200414.xml
+++ b/unearthed-arcana/2020/20200414.xml
@@ -57,15 +57,16 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description>Your Psionic Talent die is a d{{ua:psi-knight:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			<description>Your Psionic Talent die is a d{{ua:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
 			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
 			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
 		</sheet>
 		<rules>
-			<stat name="ua:psi-knight:psionic-talent-die:size" value="6" bonus="base" />
-			<stat name="ua:psi-knight:psionic-talent-die:size" value="8" bonus="base" level="5" />
-			<stat name="ua:psi-knight:psionic-talent-die:size" value="10" bonus="base" level="11" />
-			<stat name="ua:psi-knight:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Grants" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
+			<stat name="ua:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psionic-talent-die:size" value="12" bonus="base" level="17" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_REPLENISHMENT" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PROTECTIVE_FIELD" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSI_KNIGHT_PSI_POWERED_LEAP" />
@@ -116,7 +117,7 @@
 			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet action="Bonus Action" usage="1/Long Rest">
-			<description>You restore your Psionic Talent die to its starting size (d{{ua:psi-knight:psionic-talent-die:size}}).</description>
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
 
@@ -235,15 +236,16 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description>Your Psionic Talent die is a d{{ua:soulknife:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			<description>Your Psionic Talent die is a d{{ua:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
 			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
 			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
 		</sheet>
 		<rules>
-			<stat name="ua:soulknife:psionic-talent-die:size" value="6" bonus="base" />
-			<stat name="ua:soulknife:psionic-talent-die:size" value="8" bonus="base" level="5" />
-			<stat name="ua:soulknife:psionic-talent-die:size" value="10" bonus="base" level="11" />
-			<stat name="ua:soulknife:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Grants" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
+			<stat name="ua:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psionic-talent-die:size" value="12" bonus="base" level="17" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_REPLENISHMENT" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSI_BOLSTERED_KNACK" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_SOULKNIFE_PSYCHIC_WHISPERS" />
@@ -273,7 +275,7 @@
 			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet action="Bonus Action" usage="1/Long Rest">
-			<description>You restore your Psionic Talent die to its starting size (d{{ua:soulknife:psionic-talent-die:size}}).</description>
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
 
@@ -402,15 +404,16 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description>Your Psionic Talent die is a d{{ua:psionic-soul:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			<description>Your Psionic Talent die is a d{{ua:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
 			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
 			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
 		</sheet>
 		<rules>
-			<stat name="ua:psionic-soul:psionic-talent-die:size" value="6" bonus="base" />
-			<stat name="ua:psionic-soul:psionic-talent-die:size" value="8" bonus="base" level="5" />
-			<stat name="ua:psionic-soul:psionic-talent-die:size" value="10" bonus="base" level="11" />
-			<stat name="ua:psionic-soul:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<grant type="Grants" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
+			<stat name="ua:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psionic-talent-die:size" value="12" bonus="base" level="17" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSI_REPLENISHMENT" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSIONIC_DISCOVERY" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_ARCHETYPE_FEATURE_PSIONIC_SOUL_PSYCHIC_SORCERY" />
@@ -450,7 +453,7 @@
 			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet action="Bonus Action" usage="1/Long Rest">
-			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-soul:psionic-talent-die:size}}).</description>
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
 
@@ -753,19 +756,19 @@
 			<p class="indent"><strong><em>Psi Replenishment.</em></strong> As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet>
-			<description>Your Psionic Talent die is a d{{ua:wild-talent:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
+			<description>Your Psionic Talent die is a d{{ua:psionic-talent-die:size}}. If you roll the highest number on your Psionic Talent die, it decreases by one die size after the roll. If it’s a d4 and you roll a 4, it becomes unusable until you finish a long rest.
 			If you roll a 1 on your Psionic Talent die, it increases by one die size after the roll, up to its starting size.
 			Whenever you finish a long rest, your Psionic Talent die resets to its starting size.</description>
 		</sheet>
 		<rules>
-			<select type="Ability Score Improvement" name="Ability Score Increase, Wild Talent" supports="Feat" />
-			<stat name="ua:wild-talent:psionic-talent-die:size" value="6" bonus="base" />
-			<stat name="ua:wild-talent:psionic-talent-die:size" value="8" bonus="base" level="5" />
-			<stat name="ua:wild-talent:psionic-talent-die:size" value="10" bonus="base" level="11" />
-			<stat name="ua:wild-talent:psionic-talent-die:size" value="12" bonus="base" level="17" />
+			<select type="Ability Score Improvement" name="Ability Score Increase, Wild Talent" supports="Feat" />			
+			<stat name="ua:psionic-talent-die:size" value="6" bonus="base" />
+			<stat name="ua:psionic-talent-die:size" value="8" bonus="base" level="5" />
+			<stat name="ua:psionic-talent-die:size" value="10" bonus="base" level="11" />
+			<stat name="ua:psionic-talent-die:size" value="12" bonus="base" level="17" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_BOOSTED_ABILITY" />
 			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_GUIDED_STRIKE" />
-			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_REPLENISHMENT" />
+			<grant type="Archetype Feature" id="ID_WOTC_UA20200414_FEAT_FEATURE_WILD_TALENT_PSI_REPLENISHMENT" requirements="!ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
 		</rules>
 	</element>
 
@@ -793,10 +796,11 @@
 			<p>As a bonus action, you can calm your mind for a moment and restore your Psionic Talent die to its starting size. You then can’t use Psi Replenishment again until you finish a long rest.</p>
 		</description>
 		<sheet usage="1/Long Rest">
-			<description>You restore your Psionic Talent die to its starting size (d{{ua:wild-talent:psionic-talent-die:size}}).</description>
+			<description>You restore your Psionic Talent die to its starting size (d{{ua:psionic-talent-die:size}}).</description>
 		</sheet>
 	</element>
 
-	<!-- todo: use generic grant for psionic talent if published in this form -->
+	<element name="Psionic Talent feature" type="Grants" source="Unearthed Arcana: Psionic Options Revisited" id="ID_WOTC_UA20200414_GRANTS_PSIONIC_TALENT_FEATURE" />
+
 
 </elements>


### PR DESCRIPTION
**Archetypes**
- [x] Psi Knight
- [x] Soulknife
- [x] Psionic Soul

**Spells**
- [x] Intellect Fortress
- [x] Mind Sliver
- [x] Mind Thrust

**Feats**
- [x] Metabolic Control
- [x] Telekinetic
- [x] Telepathic
- [x] Tower of Iron Will
- [x] Wild Talent

Source: https://dnd.wizards.com/articles/unearthed-arcana/psionic-options-revisited