### PR TITLE
Fix description of Fire Storm spell

### DIFF
--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -3057,7 +3057,7 @@
   <element name="Fire Storm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIRE_STORM">
     <supports>Cleric, Druid, Sorcerer</supports>
     <description>
-      <p>A storm made up of sheets of roaring flame appears in a location you choose within range. The area of the storm consists of up to 10-foot cubes, which you can arrange as you wish. Each cube must have at least one face adjacent to the face of another cube. Each creature in the area must make  Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one. The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried. If you choose, plant life in the area is unaffected by this spell.</p>
+      <p>A storm made up of sheets of roaring flame appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least one face adjacent to the face of another cube. Each creature in the area must make  Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one. The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried. If you choose, plant life in the area is unaffected by this spell.</p>
     </description>
     <setters>
       <set name="keywords">fire</set>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -3057,7 +3057,8 @@
   <element name="Fire Storm" type="Spell" source="Player’s Handbook" id="ID_PHB_SPELL_FIRE_STORM">
     <supports>Cleric, Druid, Sorcerer</supports>
     <description>
-      <p>A storm made up of sheets of roaring flame appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least one face adjacent to the face of another cube. Each creature in the area must make  Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one. The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried. If you choose, plant life in the area is unaffected by this spell.</p>
+      <p>A storm made up of sheets of roaring flame appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least one face adjacent to the face of another cube. Each creature in the area must make  Dexterity saving throw. It takes 7d10 fire damage on a failed save, or half as much damage on a successful one.</p>
+      <p class="indent">The fire damages objects in the area and ignites flammable objects that aren’t being worn or carried. If you choose, plant life in the area is unaffected by this spell.</p>
     </description>
     <setters>
       <set name="keywords">fire</set>

--- a/core/players-handbook/spells.xml
+++ b/core/players-handbook/spells.xml
@@ -4,7 +4,7 @@
     <name>Spells</name>
     <description>Spells from the Player’s Handbook.</description>
     <author url="http://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook">Wizards of the Coast</author>
-    <update version="0.4.2">
+    <update version="0.4.3">
       <file name="spells.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/core/players-handbook/spells.xml" />
     </update>
   </info>


### PR DESCRIPTION
As per: https://roll20.net/compendium/dnd5e/Fire%20Storm#content

It's "up to ten 10-foot cubes" column of fire. Without the first "ten" it doesn't make any sense.