### PR TITLE
[WHAU] Awakened Undead: Multiple fixes

### DIFF
--- a/third-party/dms-guild/race-awakened-undead.xml
+++ b/third-party/dms-guild/race-awakened-undead.xml
@@ -4,7 +4,7 @@
         <name>Awakened Undead</name>
         <description>Awakened Undead Race from DM's Guild.</description>
         <author url="https://www.dmsguild.com/browse.php?author=Walrock%20Homebrew">Walrock Homebrew</author>
-        <update version="0.0.4">
+        <update version="0.0.5">
             <file name="race-awakened-undead.xml" url="https://raw.githubusercontent.com/aurorabuilder/elements/master/third-party/dms-guild/race-awakened-undead.xml" />
         </update>
     </info>
@@ -184,7 +184,7 @@
             <p class="indent">Born again out of an undying thirst for vengeance, you will not rest until the wrongs surrounding your death have been righted. Though you superficially appear similar to a zombie, complete with tattered flesh and sporadic decay, your eyes gleam with an intelligent intent, a burning passionate fury that will bring your vengeance to those who have wronged you.</p>
             <p>
             <span class="feature">Ability Score Increase. </span>Your Charisma or Strength score increases by 2.  <br />
-            <span class="feature">Eternal Vegence. </span>You know at all times the general direction of and relative distance to a specific intelligent creature of the DM’s choosing against whom you seek revenge for your death, even if the creature and you are on different planes of existence. Should this creature die by your hand or that of another, you instantly know, and your DM chooses another creature also responsible for your death for this feature to apply to, should such a creature exist. <br />
+            <span class="feature">Eternal Vengeance. </span>You know at all times the general direction of and relative distance to a specific intelligent creature of the DM’s choosing against whom you seek revenge for your death, even if the creature and you are on different planes of existence. Should this creature die by your hand or that of another, you instantly know, and your DM chooses another creature also responsible for your death for this feature to apply to, should such a creature exist. <br />
             <span class="feature">Driven. </span>You have advantage on saving throws against effects that turn undead or would cause you to be frightened.<br />
             <span class="feature">Unnatural Vitality. </span>When you drop to 0 hit points, you can choose to stay conscious instead of falling unconscious. If you do, you gain temporary hit points equal to your total character level + your Constitution modifier (minimum 1), which last for up to one minute. In this state, you can take an action or bonus action on your turn, but not both, and can move only half of your movement speed. You remain in this state until you regain hit points, or until you no longer have temporary hit points. If you lose all temporary hit points in this state while you are still at 0 hit points, you fall unconscious and begin making death saving throws as normal. Once you use this trait, you can’t use it again until you finish a long rest. <br />
             </p>
@@ -192,12 +192,12 @@
         <sheet display="false"/>
         <rules>
             <select type="Ability Score Improvement" name="Ability Score Increase (Revenant)" supports="ID_DMSG_WHAU_ASI_UNDEAD_CHARISMA|ID_DMSG_WHAU_ASI_UNDEAD_STRENGTH" />
-            <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_ETERNAL_VEGENCE" />
+            <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_ETERNAL_VENGEANCE" />
             <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_DRIVEN" />
             <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_UNNATURAL_VITALITY" />
         </rules>
     </element>
-    <element name="Eternal Vegence" type="Racial Trait" source="Walrock Homebrew: Awakened Undead" id="ID_DMSG_WHAU_RACIAL_TRAIT_ETERNAL_VEGENCE">
+    <element name="Eternal Vengeance" type="Racial Trait" source="Walrock Homebrew: Awakened Undead" id="ID_DMSG_WHAU_RACIAL_TRAIT_ETERNAL_VENGEANCE">
         <description>
             <p>You know at all times the general direction of and relative distance to a specific intelligent creature of the DM’s choosing against whom you seek revenge for your death, even if the creature and you are on different planes of existence. Should this creature die by your hand or that of another, you instantly know, and your DM chooses another creature also responsible for your death for this feature to apply to, should such a creature exist. </p>
         </description>
@@ -289,7 +289,7 @@
     <element name="Mummy" type="Sub Race" source="Walrock Homebrew: Awakened Undead" id="ID_DMSG_WHAU_SUB_RACE_MUMMY">
         <supports>Awakened Undead</supports>
         <description>
-            <p>Lingering souls of the dead and departed, Mummys are raised as servants by potent necromancers or hold onto the world themselves when there is unfinished business they have yet to accomplish. If a Mummy is charged with unfinished business it can take many forms, from protecting a loved one, to keeping a particular item safe, to simple revenge. Mummys are spectral and luminous, but are usually solid to the touch unless they expend conscious will to be otherwise. Thus, a Mummy can interact with objects as mortals do. All Mummys carry obvious and sometimes twisted marks of what caused their death, which are often quite disturbing to all but the most jaded mortals. </p>
+            <p>Lingering souls of the dead and departed, Mummies are raised as servants by potent necromancers or hold onto the world themselves when there is unfinished business they have yet to accomplish. If a Mummy is charged with unfinished business it can take many forms, from protecting a loved one, to keeping a particular item safe, to simple revenge. Mummies are spectral and luminous, but are usually solid to the touch unless they expend conscious will to be otherwise. Thus, a Mummy can interact with objects as mortals do. All Mummies carry obvious and sometimes twisted marks of what caused their death, which are often quite disturbing to all but the most jaded mortals. </p>
             <p>
             <span class="feature">Ability Score Increase. </span>Your Strength, Wisdom, or Charisma score increases by 2. <br />
             <span class="feature">Mummy Rot. </span>You can choose to make your unarmed strike deal necrotic damage instead of bludgeoning damage, and any creature hit by your unarmed strike is unable to regain hit points until the end of your next turn. If a creature is reduced to 0 hit points by your unarmed strike, it instantly disintegrates into dust, leaving behind any objects, clothing, or items on its person.<br />
@@ -303,7 +303,6 @@
             <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_MUMMY_ROT" />
             <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_DREADFUL_GLARE" />
             <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_CANOPIC_RESURRECTION" />
-            <grant type="Racial Trait" id="ID_DMSG_WHAU_RACIAL_TRAIT_INTANGIBLE" />
         </rules>
     </element>
     <element name="Mummy Rot" type="Racial Trait" source="Walrock Homebrew: Awakened Undead" id="ID_DMSG_WHAU_RACIAL_TRAIT_MUMMY_ROT">
@@ -521,12 +520,12 @@
         <requirements>ID_DMSG_WHAU_SUB_RACE_SKELETON</requirements>
         <description>
             <p><i>Prerequisite: Awakened Undead (Skeleton)</i></p>
-            <p>You add two additional arms to your frame, for a total of four. At any one time, you can hold up to four onehanded objects, a pair of two-handed objects, or a twohanded object and two one-handed objects. Also, the weight you can carry is doubled, and you gain a climbing speed of 30 feet.</p>
+            <p>You add two additional arms to your frame, for a total of four. At any one time, you can hold up to four one-handed objects, a pair of two-handed objects, or a twohanded object and two one-handed objects. Also, the weight you can carry is doubled, and you gain a climbing speed of 30 feet.</p>
             <p class="indent">You are able to use your Them Bones trait if at least two of your hands are unoccupied, and using Them Bones occupies two of your hands. If all of your hands are unoccupied, you can use Them Bones for two different purposes at the same time, though doing so occupies all your hands.</p>
             <p class="indent">Having four arms does not grant you any additional attacks, and your attacks and actions are unchanged except as listed here. </p>
         </description>
         <sheet>
-            <description>You can add an addtional 2 arms to your frame. These arms allow you hold up to four one-handed objects or a pair of two-handed objects or any combination as long as your arms allow it. You carrying capacity is also doubled.</description>
+            <description>You can add an additional 2 arms to your frame. These arms allow you hold up to four one-handed objects or a pair of two-handed objects or any combination as long as your arms allow it. You carrying capacity is also doubled.</description>
         </sheet>
         <rules>
             <stat name="speed:climb" value="30" bonus="base" />
@@ -558,12 +557,12 @@
 		    <p class="indent">Choose either Wisdom or Charisma as your spellcasting ability for these spells. Any spell gained with this ability is cast at its lowest possible spell level. At 4th level, catapult is instead cast as a 2nd level spell, becoming cast as a 3rd level spell at 8th level, a 4th level spell at 12th level, a 5th level spell at 16th level, and a 6th level spell at 20th level. You regain the ability to cast any spells provided by this feat when you finish a long rest.</p>
         </description>
 		<sheet>
-			<description>You can cast blink, catapult, and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
-			<description level="4">You can cast blink, catapult (at the 2nd level), and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
-			<description level="8">You can cast blink, catapult (at the 3rd level), and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
-			<description level="12">You can cast blink, catapult (at the 4th level), and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
-			<description level="16">You can cast blink, catapult (at the 5th level), and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
-			<description level="20">You can cast blink, catapult (at the 6th level), and invisibility (targetting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description>You can cast blink, catapult, and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description level="4">You can cast blink, catapult (at the 2nd level), and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description level="8">You can cast blink, catapult (at the 3rd level), and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description level="12">You can cast blink, catapult (at the 4th level), and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description level="16">You can cast blink, catapult (at the 5th level), and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
+			<description level="20">You can cast blink, catapult (at the 6th level), and invisibility (targeting only yourself) once per rest with this ability using either Charisma or Wisdom as your spellcasting modifier.</description>
         </sheet>
 		<rules>
             <grant type="Spell" id="ID_XGTE_SPELL_CATAPULT" />


### PR DESCRIPTION
• Intangible Trait removed from Mummy Subrace
• typo "Eternal Vegence" is replaced with "Eternal Vengeance", both in description and in ID
• typo "Mummys" is replaced with "Mummies"
• typo "targetting" is replaced with "targeting"
• other typos fixed.